### PR TITLE
Removed virtualbox guest additions from virtualization quickstart

### DIFF
--- a/en/quickstart/spatialite_quickstart.rst
+++ b/en/quickstart/spatialite_quickstart.rst
@@ -100,31 +100,6 @@ table:
       :scale: 70 %
 
 
-Using spatialite-gis
-================================================================================
-
-.. TBD: Cameron Review Comment:
-  I'm mildly in favour of removing this spatialite-gis section.
-  Should we be recommending people to use QGIS instead?
-  I'd suggest that the "Things to try" section should suggest trying
-  spatialite-gis
-
-Spatialite-gis is a simple viewer for spatialite based layers.
-
-.. TBD: Cameron Review Comment:
-  If this section is included, it requires a number of screen shots.
-
-* From the Desktop GIS folder on the Desktop run spatialite-gis
-* Click the "Connecting existing SQLite DB" button and connect to /home/user/data/spatialite/trento.sqlite
-
-You should see a map of Trento Provence in Italy
-
-   - Right click on the Highways layer and select :menuselection:`Hide`
-   - Right Click on the LocalCouncilsTrento layer and select :menuselection:`Layer Configuration->Classify` and choose "Shape Area" for the column. Select 4 Classes and click on the Min and Max color patches to choose a dark and light color. Now click to see a Choropleth display of the provence areas.
-   - Change border color by right click on LocalCouncils and select :menuselection:`Layer configuration->Graphics` and select a different color under Border Graphics.
-   - Zoom in slightly. Right click on the PopulatedPlaces layer and select :menuselection:`Indentify on`. Now click on one of the Populated Places to see the attributes for that feature.
-
-
 Running spatialite from the command line
 ================================================================================
 

--- a/en/quickstart/spatialite_quickstart.rst
+++ b/en/quickstart/spatialite_quickstart.rst
@@ -1,7 +1,7 @@
 :Author: OSGeo-Live
 :Author: Micha Silver
 :Reviewer: Cameron Shorter, LISAsoft
-:Version: osgeo-live6.5
+:Version: osgeo-live 9.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
 
@@ -21,9 +21,6 @@ SpatiaLite Quickstart
 ********************************************************************************
 
 SpatiaLite is an SQLite database engine with spatial functions added. 
-
-.. TBD: Cameron Review Comment:
-  Please check my rewording below, then remove this comment.
 
 SQLite is a Database Management System (DBMS) which is simple, robust, easy to use and very lightweight. Each SQLite database is simply a file. You can freely copy it, compress it, and port it between Windows, Linux, MacOs etc.
 

--- a/en/quickstart/virtualization_quickstart.rst
+++ b/en/quickstart/virtualization_quickstart.rst
@@ -82,31 +82,18 @@ In addition, move to the "Shared Folders" section, and click the "Add folder" (g
  .. image:: ../../images/screenshots/800x600/vmdk_shared_folders.jpg
                       :scale: 65 %
 
-Once the "Folder path" and "Folder name" are defined, click OK, and again OK to finish and close the settings window.
+You can select to make the shared folder read only, and auto-mounted. Once the "Folder path" and "Folder name" are defined, click OK, and again OK to finish and close the settings window.
 
 
 **Running the Virtual Machine**
 
 Now bootup the VM by clicking the Start (green arrow) button.
 
-Once the OSGeo system comes up, you have the option to add the VirtualBox "Guest Additions" to improve video performance, and enable the shared folders option that was defined above. The guest addition installations are supplied as an ISO file togther with the VirtualBox application from Oracle, and are not licensed as Free and Open Source Software. This ISO is mounted within the VM as a CD, and the installation is run from there. Here's how it's done:
+Once the OSGeo system comes up, add yourself to the vboxsf group so that the shared folders (defined above) are accessible by running in a terminal window:
 
-In the VirtualBox window, open the :menuselection:`Devices` menu and click :menuselection:`Install Guest Additions`. This will mount the Guest Additions as a CD drive in your OSGeo Live VM.
+``user@osgeolive:~$ sudo usermod -a -G vboxsf user``
 
-  .. image:: ../../images/screenshots/800x600/vmdk_guest_additions.jpg
-                        :scale: 80 %
-
-Once the CD folder appears, open a terminal and run the following commands:
-
-``user@osgeolive:~$ sudo apt-get update``
-
-``user@osgeolive:~$ sudo apt-get install build-essential linux-headers-generic``
-
-``user@osgeolive:~$ cd /media/VBOXADDITIONS_4.1.18_78361/``
-
-``user@osgeolive:/media/VBOXADDITIONS_4.1.18_78361$ sudo ./VBoxLinuxAdditions.run``
-
-This will complete after a few moments. Reboot your VM, and you will now be able to run in full screen mode, and mount your shared folders. In the above example, we defined a Shared Folder path on the host system and named it "GIS" in the VM Settings. To mount it within the VM, open a terminal window and run:
+In the above example, we defined a Shared Folder path on the host system and named it "GIS" in the VM Settings. The shared folder will appear in the file system under /media/sf_GIS/. To mount this folder in the user's home directory, for example, in a terminal do:
 
 ``user@osgeolive:~$ mkdir GIS``
 


### PR DESCRIPTION
Now that the virtualbox guest additions are included in the ISO, no need for the extra steps. Full screen and mounted shared folders work "out of the box". so I removed those lines from the virtualization quickstart.