### PR TITLE
ENH: add information on how to develop inside osgeo-live with otb

### DIFF
--- a/en/quickstart/otb_quickstart.rst
+++ b/en/quickstart/otb_quickstart.rst
@@ -32,6 +32,10 @@ Sample data used in this quickstart can be found here:
 
 Please download the data and extract them in the folder `/home/user/otb/`.
 
+If you want to use the OTB library and compile your C++ code inside OSGeo-Live,
+you will need to install development package **libotb-dev** and most probably
+cmake also. 
+
 
 Display metadata informations in an image 
 ================================================================================


### PR DESCRIPTION
Add info for osgeo-live user in quickstart on how to compile OTB code in the VM . It required to install extra packages that we don't wand to install by default in the ISO to save space