### PR TITLE
josm: remove support

### DIFF
--- a/en/overview/josm_overview.rst
+++ b/en/overview/josm_overview.rst
@@ -79,8 +79,6 @@ Details
 
 **API Interfaces:** Java
 
-**Support:** http://www.osgeo.org/search_profile
-
 
 .. Quickstart
 .. --------------------------------------------------------------------------------


### PR DESCRIPTION
removed support from osgeo search engine because josm is not in the technologies supported