### PR TITLE
Updated 9.5 versions

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -242,7 +242,7 @@ rst_epilog="""
 .. |osgeolive-appmenupath-52nWPS| replace:: :menuselection:`Geospatial --> Web Services --> 52North --> Start 52North WPS`
 .. |version-deegree| replace:: 3.3.13
 .. |version-gdal| replace:: 1.11.3
-.. |version-geoserver| replace:: 2.6.1
+.. |version-geoserver| replace:: 2.8.2
 .. |version-geokettle| replace:: 2.6
 .. |version-gvsig| replace:: 2.2
 .. |version-mapbender| replace:: 3.0.5.3

--- a/en/overview/cartaro_overview.rst
+++ b/en/overview/cartaro_overview.rst
@@ -58,7 +58,7 @@ Details
 
 **Licence:** GNU General Public License (GPL) version 2
 
-**Software Version:** 1.5
+**Software Version:** 1.9
 
 **Supported Platforms:** Windows, Linux, Mac
 

--- a/en/overview/cesium_overview.rst
+++ b/en/overview/cesium_overview.rst
@@ -53,7 +53,7 @@ Details
 
 **Licence:** Apache 2.0 license
 
-**Software Version:** 1.4
+**Software Version:** 1.18
 
 **Supported Platforms:**  Platform independent, depends only on a browser which supports WebGL
 

--- a/en/overview/iris_overview.rst
+++ b/en/overview/iris_overview.rst
@@ -37,7 +37,7 @@ Details
 
 **Licence:** LGPLv3
 
-**Software Version:** 1.6.1
+**Software Version:** 1.9.0
 
 **Supported Platforms:** Cross Platform Python-- Mac OS X, Windows, and Linux
 

--- a/en/overview/postgis_overview.rst
+++ b/en/overview/postgis_overview.rst
@@ -108,7 +108,7 @@ Details
 
 **Licence:** GNU General Public License (GPL) version 2
 
-**Software Version:** 2.1.3
+**Software Version:** 2.2.1
 
 **Supported Platforms:** Windows, Linux, Mac
 

--- a/en/overview/qgis_mapserver_overview.rst
+++ b/en/overview/qgis_mapserver_overview.rst
@@ -54,7 +54,7 @@ Details
 
 **Licence:** GPL
 
-**Software Version:** 2.6.1
+**Software Version:** 2.14.0
 
 **Supported Platforms:** Windows, Linux
 


### PR DESCRIPTION
I am not sure final OSGeoLive 9.5 versions, but I think that some version upgrade in "doc/en" files is necessary.

http://lists.osgeo.org/pipermail/discuss/2016-March/015709.html
http://lists.osgeo.org/pipermail/live-demo/2016-March/011005.html