### PR TITLE
Update OSM (dataset) overview & quickstart for OSGeo-Live 10.0

### DIFF
--- a/en/overview/osm_dataset_overview.rst
+++ b/en/overview/osm_dataset_overview.rst
@@ -6,7 +6,7 @@
 .. image:: ../../images/project_logos/logo-osm.png
   :alt: project logo
   :align: right
-  :target: http://www.osm.org/
+  :target: https://www.openstreetmap.org/
 
 
 OpenStreetMap (OSM)
@@ -17,7 +17,7 @@ Map Data
 
 OpenStreetMap is a crowd sourced map of the world which has grown to become one of the most detailed sources of local-scale map data available. Source map data is created and maintained by thousands of volunteers from around the world, using processes similar to the maintaining of the wikipedia encyclopedia.
 
-The most visible aspect to OSM is the online web-tile interface from http://www.openstreetmap.org, but the maps can also be viewed, imported, or edited in many applications such as :doc:`Quantum GIS <qgis_overview>` , :doc:`OpenLayers <openlayers_overview>`, ArcGIS and dedicated OSM applications.
+The most visible aspect to OSM is the online web-tile interface from https://www.openstreetmap.org, but the maps can also be viewed, imported, or edited in many applications such as :doc:`QGIS <qgis_overview>` , :doc:`OpenLayers <openlayers_overview>`, ArcGIS and dedicated OSM applications.
 
 The heart of the project is the underlying data which is open for all to edit, view, or create custom rendered maps. Fundamentally OSM's focus is on the data, the rich maps simply fall out of this.
 
@@ -61,7 +61,7 @@ The smaller CBD extract is loaded into another PostGIS database called "pgroutin
 Details
 --------------------------------------------------------------------------------
 
-**Website:** http://www.openstreetmap.org/ 
+**Website:** https://www.openstreetmap.org/
 
 **License:** `Open Data Commons Open Database License (ODbL) <http://opendatacommons.org/licenses/odbl/>`_
 
@@ -71,5 +71,5 @@ Details
 
 **Spatial coordinate system:** Latitude-Longitude WGS84
 
-**Support:** http://wiki.openstreetmap.org/
+**Support:** https://www.openstreetmap.org/help
 

--- a/en/overview/osm_overview.rst
+++ b/en/overview/osm_overview.rst
@@ -14,7 +14,7 @@ OpenStreetMap
 Tools for mapping the world
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`OpenStreetMap <http://www.openstreetmap.org>`_ is a project aimed
+`OpenStreetMap <https://www.openstreetmap.org>`_ is a project aimed
 squarely at creating and providing free geographic data such as street
 maps to anyone who wants them. The project was started because most maps
 you think of as free actually have legal or technical restrictions on their
@@ -48,11 +48,11 @@ Core Features
 Details
 --------------------------------------------------------------------------------
 
-**Website:** http://www.openstreetmap.org
+**Website:** https://www.openstreetmap.org
 
 **Licences:**
 
-* OpenStreetMap data: http://wiki.openstreetmap.org/index.php/OpenStreetMap_License
+* OpenStreetMap data: https://www.openstreetmap.org/copyright
 
 * JOSM: GNU General Public License (GPL) version 2
 
@@ -65,20 +65,20 @@ Details
 
 **Software Versions:**
 
-* JOSM: Latest stable snapshot (svn r7347)
+* JOSM: Latest stable snapshot (svn r10526)
 
-* Merkaartor: 1.18.1
+* Merkaartor: 1.18.2
 
-* Osmosis: 0.40.1
+* Osmosis: 0.44.1
 
-* osm2pgsql: 0.85.0
+* osm2pgsql: 0.88.1
 
 
 **Supported Platforms:** GNU/Linux, Mac OSX, MS Windows
 
 **API Interfaces (data):** REST (via Xapi), XML
 
-**Support:** http://wiki.openstreetmap.org/
+**Support:** https://www.openstreetmap.org/help
 
 
 Quickstart

--- a/en/quickstart/osm_quickstart.rst
+++ b/en/quickstart/osm_quickstart.rst
@@ -7,7 +7,7 @@
   :scale: 100 %
   :alt: project logo
   :align: right
-  :target: http://www.osm.org
+  :target: https://www.openstreetmap.org
 
 
 ********************************************************************************
@@ -45,7 +45,7 @@ written in Java. The current version supports stand alone GPX tracks,
 GPX track data from OSM database and existing nodes, line segments and
 metadata tags from the OSM database.
 
-* Homepage: http://josm.openstreetmap.de
+* Homepage: https://josm.openstreetmap.de
 
 The JOSM plugin collection contains the following plugins:
 
@@ -64,9 +64,8 @@ The JOSM plugin collection contains the following plugins:
 Further reading
 --------------------------------------------------------------------------------
 
-* User guide: http://wiki.openstreetmap.org/wiki/JOSM/Guide
+* User guide: https://wiki.openstreetmap.org/wiki/JOSM/Guide
 * `Video tutorial <http://showmedo.com/videotutorials/video?name=1800050&amp;fromSeriesID=180>`_
-* Online tutorial: http://www.use-it.be/europe/docs/OSMmanual/
 * Open the sample data with :menuselection:`File --> Open... --> /usr/local/share/data/osm/feature_city.osm.bz2`
 * Further instructions are given when you launch the application.
 
@@ -78,7 +77,7 @@ Merkaartor
 It's a bit more user friendly than JOSM, but has a few less features.
 
 * Homepage: http://merkaartor.be
-* Online help: http://merkaartor.be/wiki/merkaartor/Documentation
+* Online help: https://wiki.openstreetmap.org/wiki/Merkaartor/Documentation
 
 
 Osmosis
@@ -86,7 +85,7 @@ Osmosis
 **Osmosis** is a highly capable utility program for performing many tasks at
 a raw level on OSM data. This includes data import and export to databases,
 sorting, cleaning, and creating data dumps. See
-the `detailed usage page <http://wiki.openstreetmap.org/wiki/Osmosis#Usage>`_ for
+the `detailed usage page <https://wiki.openstreetmap.org/wiki/Osmosis#Usage>`_ for
 more information. A simple report of author contributions can be performed
 as follows. Open a new Terminal, and at a command prompt type the following:
 
@@ -106,5 +105,5 @@ into a format that can be loaded into PostgreSQL (PostGIS). It is often
 used to render OSM data visually using Mapnik, as Mapnik can query
 PostgreSQL for map data, but does not work directly with OSM files.
 
-* Homepage: http://wiki.openstreetmap.org/wiki/Osm2pgsql
+* Homepage: https://wiki.openstreetmap.org/wiki/Osm2pgsql
 


### PR DESCRIPTION
Separate commits for each file:

1)  Update OSM overview for OSGeo-Live 10.0.

- Switch URLs to HTTPS
- Update license URL to openstreetmap.org/copyright
- Update JOSM/Merkaartor/osmosis/osm2pgsql version
- Update support URL to openstreetmap.org/help

2)  Update OSM dataset overview for OSGeo-Live 10.0.

- Switch URLs to HTTPS
- Rename Quantum GIS to QGIS
- Update support URL to openstreetmap.org/help

3)  Update OSM quickstart for OSGeo-Live 10.0.

- Switch URLs to HTTPS
- Drop JOSM Online tutorial link, no longer available
- Switch Merkaartor Online help link to OSM wiki