### PR TITLE
Fix broken GeoServer links.

### DIFF
--- a/ca/overview/geoserver_overview.rst
+++ b/ca/overview/geoserver_overview.rst
@@ -8,7 +8,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_incubation.png
   :scale: 100 %
@@ -89,7 +89,7 @@ Suporta nombrosos estàndards de l'Open Geospatial Consortium  (OGC):
 Detalls
 --------------------------------------------------------------------------------
 
-**Lloc web:** http://geoserver.org/display/GEOS/Welcome
+**Lloc web:** http://geoserver.org/
 
 **Llicència:** GNU General Public License (GPL) version 2
 
@@ -99,7 +99,7 @@ Detalls
 
 **Interfícies API:** WMS, WFS, WCS, REST
 
-**Suport:** http://geoserver.org/display/GEOS/Commercial+Support
+**Suport:** http://geoserver.org/support/
 
 Guia ràpida
 --------------------------------------------------------------------------------

--- a/de/overview/geoserver_overview.rst
+++ b/de/overview/geoserver_overview.rst
@@ -7,7 +7,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_project.png
   :scale: 100 %
@@ -76,7 +76,7 @@ Implementierte Standards
 Details
 --------------------------------------------------------------------------------
 
-**Webseite:** http://geoserver.org/display/GEOS/Welcome
+**Webseite:** http://geoserver.org/
 
 **Lizenz:** GNU General Public License (GPL) version 2
 
@@ -86,7 +86,7 @@ Details
 
 **API Schnittstellen:** WMS, WFS, WCS, REST
 
-**Support:** http://geoserver.org/display/GEOS/Commercial+Support
+**Support:** http://geoserver.org/support/
 
 Quickstart
 --------------------------------------------------------------------------------

--- a/el/overview/geoserver_overview.rst
+++ b/el/overview/geoserver_overview.rst
@@ -9,7 +9,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_incubation.png
   :scale: 100 %
@@ -78,7 +78,7 @@ GeoServer
 Λεπτομέρειες
 --------------------------------------------------------------------------------
 
-**Αρχική Ιστοσελίδα:** http://geoserver.org/display/GEOS/Welcome
+**Αρχική Ιστοσελίδα:** http://geoserver.org/
 
 **Άδεια:** GNU General Public License (GPL) version 2
 
@@ -88,7 +88,7 @@ GeoServer
 
 **Προγραμματιστικές διεπαφές:** WMS, WFS, WCS, REST
 
-**Υποστήριξη:** http://geoserver.org/display/GEOS/Commercial+Support
+**Υποστήριξη:** http://geoserver.org/support/
 
 
 

--- a/en/overview/geoserver_overview.rst
+++ b/en/overview/geoserver_overview.rst
@@ -7,7 +7,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_project.png
   :scale: 100 %
@@ -78,7 +78,7 @@ Support of numerous Open Geospatial Consortium  (OGC) standards:
 Details
 --------------------------------------------------------------------------------
 
-**Website:** http://geoserver.org/display/GEOS/Welcome
+**Website:** http://geoserver.org/
 
 **Licence:** GNU General Public License (GPL) version 2
 
@@ -88,7 +88,7 @@ Details
 
 **API Interfaces:** WMS, WFS, WCS, REST
 
-**Support:** http://geoserver.org/display/GEOS/Commercial+Support
+**Support:** http://geoserver.org/support/
 
 Quickstart
 --------------------------------------------------------------------------------

--- a/es/overview/geoserver_overview.rst
+++ b/es/overview/geoserver_overview.rst
@@ -11,7 +11,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_project.png 
   :scale: 100 %
@@ -98,7 +98,7 @@ Standares Implementados
 Detalles
 --------------------------------------------------------------------------------
 
-**Sitio Web:** http://geoserver.org/display/GEOS/Welcome
+**Sitio Web:** http://geoserver.org/
 
 **Licencia:** GNU General Public License (GPL) version 2
 
@@ -108,7 +108,7 @@ Detalles
 
 **Interfaces API:** WMS, WFS, WCS, REST
 
-**Soporte:** http://geoserver.org/display/GEOS/Commercial+Support
+**Soporte:** http://geoserver.org/support/
 
 Quickstart
 --------------------------------------------------------------------------------

--- a/fr/overview/geoserver_overview.rst
+++ b/fr/overview/geoserver_overview.rst
@@ -7,7 +7,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: Logo du projet
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_incubation.png
   :scale: 100 %
@@ -83,7 +83,7 @@ Support de nombreux standards de l'Open Geospatial Consortium  (OGC):
 Détails
 --------------------------------------------------------------------------------
 
-**Site web:** http://geoserver.org/display/GEOS/Welcome
+**Site web:** http://geoserver.org/
 
 **Licence:** Licence GNU General Public (GPL) version 2
 
@@ -93,7 +93,7 @@ Détails
 
 **Interfaces de l'API:** WMS, WFS, WCS, REST
 
-**Support:** http://geoserver.org/display/GEOS/Commercial+Support
+**Support:** http://geoserver.org/support/
 
 Guide de démarrage rapide
 --------------------------------------------------------------------------------

--- a/it/overview/geoserver_overview.rst
+++ b/it/overview/geoserver_overview.rst
@@ -8,7 +8,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_project.png
   :scale: 100 %
@@ -89,7 +89,7 @@ Supporto di numerosi standard Open Geospatial Consortium  (OGC):
 Dettagli
 --------------------------------------------------------------------------------
 
-**Sito web:** http://geoserver.org/display/GEOS/Welcome
+**Sito web:** http://geoserver.org/
 
 **Licenza:** GNU General Public License (GPL) version 2
 
@@ -99,7 +99,7 @@ Dettagli
 
 **Interfacce API:** WMS, WFS, WCS, REST
 
-**Supporto:** http://geoserver.org/display/GEOS/Commercial+Support
+**Supporto:** http://geoserver.org/support/
 
 Guida rapida
 --------------------------------------------------------------------------------

--- a/ja/overview/geoserver_overview.rst
+++ b/ja/overview/geoserver_overview.rst
@@ -7,7 +7,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_project.png
   :scale: 100 %
@@ -79,7 +79,7 @@ GeoServer は `Open Geospatial Consortium <http://www.opengeospatial.org>`_ (OGC
 詳細
 --------------------------------------------------------------------------------
 
-**ウェブサイト:** http://geoserver.org/display/GEOS/Welcome
+**ウェブサイト:** http://geoserver.org/
 
 **ライセンス:** GNU General Public License (GPL) version 2
 
@@ -89,7 +89,7 @@ GeoServer は `Open Geospatial Consortium <http://www.opengeospatial.org>`_ (OGC
 
 **API インターフェース:** WMS、 WFS、 WCS、 REST
 
-**サポート:** http://geoserver.org/display/GEOS/Commercial+Support
+**サポート:** http://geoserver.org/support/
 
 クイックスタート
 --------------------------------------------------------------------------------

--- a/ko/overview/geoserver_overview.rst
+++ b/ko/overview/geoserver_overview.rst
@@ -7,7 +7,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_incubation.png
   :scale: 100 %
@@ -83,7 +83,7 @@ Support of numerous Open Geospatial Consortium  (OGC) standards:
 Details
 --------------------------------------------------------------------------------
 
-**Website:** http://geoserver.org/display/GEOS/Welcome
+**Website:** http://geoserver.org/
 
 **Licence:** GNU General Public License (GPL) version 2
 
@@ -93,7 +93,7 @@ Details
 
 **API Interfaces:** WMS, WFS, WCS, REST
 
-**Support:** http://geoserver.org/display/GEOS/Commercial+Support
+**Support:** http://geoserver.org/support/
 
 Quickstart
 --------------------------------------------------------------------------------

--- a/pl/overview/geoserver_overview.rst
+++ b/pl/overview/geoserver_overview.rst
@@ -8,7 +8,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_incubation.png
   :scale: 100 %
@@ -106,7 +106,7 @@ Zaimplementowane standardy
 Szczegóły
 --------------------------------------------------------------------------------
 
-**Strona internetowa:** http://geoserver.org/display/GEOS/Welcome
+**Strona internetowa:** http://geoserver.org/
 
 **Licencja:** Powszechna Licencja Publiczna GNU (GPL) wersja 2
 
@@ -116,7 +116,7 @@ Szczegóły
 
 **Interfejsy API:** WMS, WFS, WCS, REST
 
-**Wsparcie:** http://geoserver.org/display/GEOS/Commercial+Support
+**Wsparcie:** http://geoserver.org/support/
 
 Szybkie wprowadzenie
 --------------------------------------------------------------------------------

--- a/ru/overview/geoserver_overview.rst
+++ b/ru/overview/geoserver_overview.rst
@@ -7,7 +7,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: логотип проекта
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_incubation.png
   :scale: 100 %
@@ -89,7 +89,7 @@ GeoServer — это эталонная реализация стандарто�
 Подробности
 --------------------------------------------------------------------------------
 
-**Веб-сайт:** http://geoserver.org/display/GEOS/Welcome
+**Веб-сайт:** http://geoserver.org/
 
 **Лицензия:** `GPL версия 2 <http://www.gnu.org/licenses/gpl-2.0.html>`_
 
@@ -99,7 +99,7 @@ GeoServer — это эталонная реализация стандарто�
 
 **Интерфейсы API:** WMS, WFS, WCS, REST
 
-**Поддержка:** http://geoserver.org/display/GEOS/Commercial+Support
+**Поддержка:** http://geoserver.org/support/
 
 Начало работы
 --------------------------------------------------------------------------------

--- a/zh/overview/geoserver_overview.rst
+++ b/zh/overview/geoserver_overview.rst
@@ -7,7 +7,7 @@
 .. image:: ../../images/project_logos/logo-GeoServer.png
   :alt: project logo
   :align: right
-  :target: http://geoserver.org/display/GEOS/Welcome
+  :target: http://geoserver.org/
 
 .. image:: ../../images/logos/OSGeo_incubation.png
   :scale: 100 %
@@ -77,7 +77,7 @@ GeoServer已成了Geospatial Web的一个核心组件。
 详情请见
 --------------------------------------------------------------------------------
 
-**网站:** http://geoserver.org/display/GEOS/Welcome
+**网站:** http://geoserver.org/
 
 **版权:** GNU General Public License (GPL) version 2
 
@@ -87,7 +87,7 @@ GeoServer已成了Geospatial Web的一个核心组件。
 
 **API接口:** WMS, WFS, WCS, REST
 
-**支持:** http://geoserver.org/display/GEOS/Commercial+Support
+**支持:** http://geoserver.org/support/
 
 快速入门
 --------------------------------------------------------------------------------


### PR DESCRIPTION
As reported by @cvvergara on IRC:
```
02:49 -!- cvvergara [~chatzilla@187.230.16.254] has joined #osgeolive
02:53 < cvvergara> Sorry to bother in your well deserved rest. I am using a vm on osgeo-live, and this is the first time I use geoServer ever in my life.
02:53 < cvvergara> In  https://live.osgeo.org/en/overview/geoserver_overview.html has a link to the website that is broken.
02:53 < sigabrt> Title: GeoServer OSGeo-Live 10.0 Documentation (at live.osgeo.org)
02:54 < cvvergara> Website: http://geoserver.org/display/GEOS/Welcome  <--- that link is broken
```
The support URL was also broken.