### PR TITLE
Add notes within presentation

### DIFF
--- a/de/presentation/index.html
+++ b/de/presentation/index.html
@@ -2231,7 +2231,7 @@ They are a bit like a spreadsheet in that each cell can contain code or a formul
              progress: true,
              history: true,
              center: true,
-	     showNotes: true,
+	     showNotes: true, // shows explaining text within the slides - you should uncomment this if you present the slides
          
              theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
              transition: Reveal.getQueryHash().transition || 'default', // default/cube/page/concave/zoom/linear/fade/none

--- a/de/presentation/index.html
+++ b/de/presentation/index.html
@@ -2231,6 +2231,7 @@ They are a bit like a spreadsheet in that each cell can contain code or a formul
              progress: true,
              history: true,
              center: true,
+	     showNotes: true,
          
              theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
              transition: Reveal.getQueryHash().transition || 'default', // default/cube/page/concave/zoom/linear/fade/none

--- a/en/presentation/index.html
+++ b/en/presentation/index.html
@@ -956,6 +956,7 @@
              progress: true,
              history: true,
              center: true,
+             showNotes: true, 
 
              theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
              transition: Reveal.getQueryHash().transition || 'default', // default/cube/page/concave/zoom/linear/fade/none

--- a/en/presentation/index.html
+++ b/en/presentation/index.html
@@ -956,7 +956,7 @@
              progress: true,
              history: true,
              center: true,
-             showNotes: true, 
+             showNotes: true, // shows explaining text within the slides - you should uncomment this if you present the slides
 
              theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
              transition: Reveal.getQueryHash().transition || 'default', // default/cube/page/concave/zoom/linear/fade/none


### PR DESCRIPTION
The presentation shows mostly pictures of the projects. It would be good to show also the text in order to explain the projects.