### PR TITLE
Document use of dd to write isohybrid+UEFI ISO images to USB drive

### DIFF
--- a/en/quickstart/usb_quickstart.rst
+++ b/en/quickstart/usb_quickstart.rst
@@ -21,8 +21,24 @@ Requirements
  * For a 4 GB USB flash drive, use osgeo-live-mini ISO (without Windows and Mac installers), without persistence.
  * For a 8+ GB USB flash drive, use either osgeo-live-mini ISO, or osgeo-live ISO (with Windows and Mac installers). 8+ GB is recommended if you wish to support persistence.
 
+Creating bootable USB drive with ``dd`` under Linux
+--------------------------------------------------------------------------------
 
-Creating bootable USB drive from Ubuntu
+ISO images for OSGeo-Live 10.5 and later are *isohybrid* (and for amd64, also support UEFI boot). Under Linux, these images can be written directly to the block device for a USB drive with the ``dd`` command-line utility:
+
+.. code-block:: console
+
+   sudo dd if=osgeo-live-10.5-amd64.iso of=/dev/sdX bs=4M; sync
+
+* ``/dev/sdX`` is the block device for the USB drive, where ``X`` might be ``b`` or ``c``.
+* Use ``lsblk`` to list block devices and ``dmesg`` to see kernel messages identifying the USB drive when it is connected.
+* The USB drive should not be mounted.
+* ``sudo`` is not required if the command is run as ``root``.
+
+.. warning::
+   Be certain to select the correct block device as ``dd`` will overwrite it without question, even if it is your primary system drive.
+
+Creating bootable USB drive with Ubuntu Startup Disk Creator
 --------------------------------------------------------------------------------
 
 (This is the recommended process for creating a USB. It is applicable to Ubuntu and Ubuntu variants such as OSGeo-Live.)

--- a/osgeolive.css
+++ b/osgeolive.css
@@ -52,6 +52,11 @@ h2 {
 	font-size:1.5em;	
 }
 
+/* for consistency with "div.admonition, div.warning" from sphinxdoc.css (".. note::" and ".. warning::") */
+.highlight {
+	margin: 1em 0 1em 0 !important;
+}
+
 .contents {
 	font-size:0.9em;
 	line-height:1.4em;


### PR DESCRIPTION
The CSS change fixes an overflowing right margin in code blocks, to match notes and warnings. I tested this change with code blocks in the OpenLayers and pgRouting quickstarts and it fixes the right borders for those as well. I did not spot anything broken. More tests welcome.