### PR TITLE
Update GeoMoose to 2.9.2

### DIFF
--- a/en/quickstart/geomoose_quickstart.rst
+++ b/en/quickstart/geomoose_quickstart.rst
@@ -1,5 +1,5 @@
 :Author: Bob Basques
-:Version: GeoMoose 2.8.0
+:Version: GeoMoose 2.9.2
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
 .. image:: ../../images/project_logos/logo-geomoose_w-title.png


### PR DESCRIPTION
GeoMoose 2.9.2 is the latest bugfix release in the GeoMoose 2.9 series.