### PR TITLE
udig QS : Added tip how to work w local GeoServer

### DIFF
--- a/en/quickstart/udig_quickstart.rst
+++ b/en/quickstart/udig_quickstart.rst
@@ -236,9 +236,11 @@ available layers of information that you can mix into your own maps.
 .. note:: If you are not connected to the Internet run |osgeolive-appmenupath-geoserver| 
    for a local WMS. The script will open a page with a "Service Capabilities" section and two links for WMS Services 
    you can drag into your empty map.
+   
+.. tip:: You can copy a WMS URL (e.g. for :`WMS 1.1.1`_) from right panel of :`GeoServer Welcome page`_ and "paste" it either on the **Map** view or the **Layers** view. A wizard shows you the layers you can add to the **Map**. You can also connect to Web Map Servers using the **Add Data** (:menuselection:`Layer --> Add...`) Wizard and paste WMS URL right there.
 
-.. tip:: You can also connect to Web Map Servers using the **Add Data** (:menuselection:`Layer --> Add...`) Wizard
-  for Drag and Drop.
+	.. _GeoServer Welcome page: http://localhost:8082/geoserver/web
+	.. _WMS 1.1.1: http://localhost:8082/geoserver/ows?service=wms&version=1.1.1&request=GetCapabilities
 
 #. Select :menuselection:`File --> New --> New Map` from the menu bar
 


### PR DESCRIPTION
Modified tip shows how to use OSGeo Live GeoServer installation (http://localhost:8082/geoserver/) and add a Layer this WMS service.