### PR TITLE
Retire OGC Standards writeups

### DIFF
--- a/en/overview/overview.rst
+++ b/en/overview/overview.rst
@@ -115,7 +115,7 @@ Geospatial Libraries
 * :doc:`jts_overview` - Java Topology Suite
 * :doc:`geotools_overview` - Java GIS Toolkit 
 * :doc:`geos_overview` - C/C++ Spatial Library 
-* :doc:`proj4_overview` - [:doc:`QuickStart <../quickstart/proj4_quickstart>`] - Coordinate Reference System Transformations (MetaCRS) 
+* :doc:`proj4_overview` - [:doc:`QuickStart <../quickstart/proj4_quickstart>`] - Coordinate Reference System Transformations
 * :doc:`liblas_overview` - [:doc:`QuickStart <../quickstart/liblas_quickstart>`] - LiDAR Data Access 
 * :doc:`iris_overview` - [:doc:`QuickStart <../quickstart/iris_quickstart>`] - Meteorology and Climatology
 
@@ -128,7 +128,9 @@ Available on Microsoft Windows only:
 * :doc:`mapwindow_overview` - [:doc:`QuickStart <../quickstart/mapwindow_quickstart>`] - Microsoft Windows based Desktop GIS
 
 Available from prior OSGeo-Live releases:
+--------------------------------------------------------------------------------
 
+* :doc:`OGC Standard descriptions <../standards/standards>` - retired after OSGeo-Live 10.5
 * :doc:`mapguide_overview` - [:doc:`QuickStart <../quickstart/mapguide_quickstart>`] - Web Service, not included after OSGeo-Live 5.0 (to save disk space)
 * `Geopublisher <http://en.geopublishing.org/Geopublisher>`_  - Catalogue, retired after OSGeo-Live 6.0
 * `AtlasStyler <http://en.geopublishing.org/AtlasStyler>`_ - Style Editor, retired after OSGeo-Live 6.0

--- a/themes/howto/page.html
+++ b/themes/howto/page.html
@@ -29,7 +29,7 @@
             <ul id="top-nav">
               <li><a href="../index.html">Home</a></li>
               <li><a href="../overview/overview.html">Contents</a></li>
-              <li><a href="../standards/standards.html">Standards</a></li>
+              <--li><a href="../standards/standards.html">Standards</a></li-->
               <li><a href="../download.html">Download</a></li>
               <li><a href="../metrics.html">Metrics</a></li>
               <li><a href="../sponsors.html">Sponsors</a></li>

--- a/themes/overview/page.html
+++ b/themes/overview/page.html
@@ -50,7 +50,7 @@
             <ul id="top-nav">
               <li><a href="../index.html">Home</a></li>
               <li><a href="../overview/overview.html">Contents</a></li>
-              <li><a href="../standards/standards.html">Standards</a></li>
+              <!--li><a href="../standards/standards.html">Standards</a></li-->
               <li><a href="../download.html">Download</a></li>
               <li><a href="../metrics.html">Metrics</a></li>
               <li><a href="../sponsors.html">Sponsors</a></li>


### PR DESCRIPTION
This drops the "Standards" tab from the tool bar, and adds "OGC Standard descriptions - retired after OSGeo-Live 10.5" to the overview.rst
The standards docs are still viewable, but they are now hard to find, (in line with them not being kept up to date).