### PR TITLE
fixing mapwindow_quickstart tables

### DIFF
--- a/el/quickstart/mapwindow_quickstart.rst
+++ b/el/quickstart/mapwindow_quickstart.rst
@@ -69,16 +69,16 @@ Files\\MapWindow\\Plugins. Μερικές φορές ένα πρόσθετο ε�
 
 ================================================================================  =================================================================
 ================================================================================  =================================================================
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomin.png          Μεγέθυνση: είτε κάντε κλικ στην περιοχή ενδιαφέροντος είτε σωγαρφίστε ένα περιβάλον ορθογώνιο. Μπορείτε επίσης να χρησιμοποιήσετε το ροδάκι του ποντικιού.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomout.png         Σμίκρυνση.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomfullextent.png  Απεικόνιση του συνόλου της έκτασης όλων των επιπέδων.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomselected.png    Απεικόνιση της έκτασης των επιλεγμένων σχημάτων στο επίπεδο.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomprevious.png    Επιλογή προηγούμενης απεικόνισης.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomnext.png        Επιλογή επόμενης απεικόνισης.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomlayer.png       Απεικόνιση της έκτασης του ενεργού επιπέδου.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-pan.png             Αλλαγή της απεικονιζόμενης επιφάνειας με κύλιση.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-select.png          Επιλογή σχημάτων από το ενεργό επίπεδο. Χρησιμοποιείστε παράλληλα το πλήκτρο Ctrl για να επιλέξετε περισσότερα του ενός ή σχηματίστε τον περιβάλλον τους ορθογώνιο.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-measure.png         Εμφανίζει ένα [παράθυρο διαλόγου με την περίμετρο και το εμβαδό των σχημάτων που έχουν επιλεγεί ή ζωγραφιστεί με το ποντίκι.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-identify.png        Εμφανίζει τα χαρακτηριστικά των σχημάτων στο επιλεγμένο επίπεδο.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomin.png                 Μεγέθυνση: είτε κάντε κλικ στην περιοχή ενδιαφέροντος είτε σωγαρφίστε ένα περιβάλον ορθογώνιο. Μπορείτε επίσης να χρησιμοποιήσετε το ροδάκι του ποντικιού.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomout.png                Σμίκρυνση.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomfullextent.png         Απεικόνιση του συνόλου της έκτασης όλων των επιπέδων.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomselected.png           Απεικόνιση της έκτασης των επιλεγμένων σχημάτων στο επίπεδο.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomprevious.png           Επιλογή προηγούμενης απεικόνισης.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomnext.png               Επιλογή επόμενης απεικόνισης.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomlayer.png              Απεικόνιση της έκτασης του ενεργού επιπέδου.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-pan.png                    Αλλαγή της απεικονιζόμενης επιφάνειας με κύλιση.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-select.png                 Επιλογή σχημάτων από το ενεργό επίπεδο. Χρησιμοποιείστε παράλληλα το πλήκτρο Ctrl για να επιλέξετε περισσότερα του ενός ή σχηματίστε τον περιβάλλον τους ορθογώνιο.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-measure.png                Εμφανίζει ένα [παράθυρο διαλόγου με την περίμετρο και το εμβαδό των σχημάτων που έχουν επιλεγεί ή ζωγραφιστεί με το ποντίκι.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-identify.png               Εμφανίζει τα χαρακτηριστικά των σχημάτων στο επιλεγμένο επίπεδο.
 ================================================================================  =================================================================
 

--- a/ru/quickstart/mapwindow_quickstart.rst
+++ b/ru/quickstart/mapwindow_quickstart.rst
@@ -68,17 +68,17 @@ MapWindow может отображать различные виды геода
 
 ================================================================================  =================================================================
 ================================================================================  =================================================================
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomin.png          Увеличить: либо щёлкните в нужную область, либо нарисуйте охватывающий прямоугольник. Увеличение и уменьшение также может быть сделано с помощью колеса прокрутки мыши.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomout.png         Уменьшить.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomfullextent.png  Масштабировать до охвата всех видимых слоёв.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomselected.png    Масштабировать для выбранных объектов целевого слоя.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomprevious.png    Перейти к списку предыдущих видов карты (охватов).
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomnext.png        Перейти к списку последующих видов карты (охватов).
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomlayer.png       Перейти к охвату целевого слоя.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-pan.png             Щёлкните и перетащите карту.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-select.png          Выбор объектов целевого слоя. Для выбора нескольких объектов удерживайте клавишу Ctrl или нарисуйте охватывающий прямоугольник. См. раздел 4.2 для получения дополнительной информации по выборкам.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-measure.png         Открывает диалог для отображения информации о периметре и площади выбранных объектов из целевого слоя, или объектов, нарисованных при помощи мыши.
-.. image:: /images/screenshots/800x600/mapwindow-toolbar-identify.png        Нажмите для просмотра атрибутов объектов целевого слоя.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomin.png                 Увеличить: либо щёлкните в нужную область, либо нарисуйте охватывающий прямоугольник. Увеличение и уменьшение также может быть сделано с помощью колеса прокрутки мыши.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomout.png                Уменьшить.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomfullextent.png         Масштабировать до охвата всех видимых слоёв.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomselected.png           Масштабировать для выбранных объектов целевого слоя.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomprevious.png           Перейти к списку предыдущих видов карты (охватов).
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomnext.png               Перейти к списку последующих видов карты (охватов).
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-zoomlayer.png              Перейти к охвату целевого слоя.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-pan.png                    Щёлкните и перетащите карту.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-select.png                 Выбор объектов целевого слоя. Для выбора нескольких объектов удерживайте клавишу Ctrl или нарисуйте охватывающий прямоугольник. См. раздел 4.2 для получения дополнительной информации по выборкам.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-measure.png                Открывает диалог для отображения информации о периметре и площади выбранных объектов из целевого слоя, или объектов, нарисованных при помощи мыши.
+.. image:: /images/screenshots/800x600/mapwindow-toolbar-identify.png               Нажмите для просмотра атрибутов объектов целевого слоя.
 ================================================================================  =================================================================
 
 ==============================


### PR DESCRIPTION
Mapwindow tables have an error

- https://travis-ci.org/OSGeo/OSGeoLive-doc/builds/246755154#L3471
- https://travis-ci.org/OSGeo/OSGeoLive-doc/builds/246755154#L3931

## tasks

- [ ] fix tables in `el` & `ru` version of mapwindow_quickstart.rst