### PR TITLE
More typo fixes

### DIFF
--- a/de/overview/cesium_overview.rst
+++ b/de/overview/cesium_overview.rst
@@ -23,9 +23,9 @@ Cesium ist eine JavaScript Bibliothek zur Erstellung von 3D Globen und 2D Karten
 
 Kernfunktionen
 --------------------------------------------------------------------------------
-* Dynamic räumliche Darstellung:
+* Dynamische räumliche Darstellung:
 
-  * Erzeugt Daten gesteuerte, zeitdynamische Szenen mit `CZML <https://github.com/AnalyticalGraphicsInc/cesium/wiki/CZML-Guide>`_.
+  * Erzeugt Daten-gesteuerte, zeitdynamische Szenen mit `CZML <https://github.com/AnalyticalGraphicsInc/cesium/wiki/CZML-Guide>`_.
   * Visualisiert ein hochauflösendes weltweites Terrain.
   * Zeichnet Rastererbenen mit Hilfe von WMS, TMS, OpenStreetMaps, Bing, und Esri Standards.
   * Zeichnet Vektor Daten über GeoJSON und TopoJSON.
@@ -34,9 +34,9 @@ Kernfunktionen
 
 * Entwickelt für Performanz und Präzision:
 
-  * Optimiertes WebGL über stabelweise und effizientes Auslesen von Hardware beschleunigten Graphiken.
+  * Optimiertes WebGL um die Graphiken effizient zu beschleunigen.
   * Zeichnet eine große Auswahl an Geometrien inklusive Polylinien, Polygonen, Marker, Beschriftungen, Verdrängungen und Korridore.
-  * Kontroolliert die Kamera und erzeugt Flugrouten.
+  * Kontrolliert die Kamera und erzeugt Flugrouten.
   * Verwendet Standard Widgets zur kontrolle der Animationszeit, Auswahl von Bildebenen und Zoom auf Positionen.
 
 * Eine API, drei Ansichten: 

--- a/de/quickstart/cesium_quickstart.rst
+++ b/de/quickstart/cesium_quickstart.rst
@@ -47,10 +47,10 @@ Auswahl der Kartenebene
 
 Was kommt als Nächstes?
 ==============================
-* Es gibt Video Tutorials `unter <https://www.youtube.com/playlist?list=PLBk_Dtk-_Tlm4STvXKFEdfUWylPemo-9V>`_.
+* Es gibt Video Tutorials `auf Youtube <https://www.youtube.com/playlist?list=PLBk_Dtk-_Tlm4STvXKFEdfUWylPemo-9V>`_.
 
-* Webbasierte Tutorials `unter <http://cesiumjs.org/tutorials.html>`_.
+* Webbasierte Tutorials `auf cesiumjs.org <http://cesiumjs.org/tutorials.html>`_.
 
-* Sie können einige schnelle Anwendungen  über die Sandburg Webseite unter der folgenden Adresse entwickeln `Link <http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Custom%20DataSource.html&label=Tutorials>`_.
+* Sie können einige einfache Anwendungen über die cesiumjs Webseite unter der folgenden Adresse `entwickeln <http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Custom%20DataSource.html&label=Tutorials>`_.
 
-* Eine ausführliche Dokumentation finden Sie lokal `unter <http://localhost/cesium/>`_.
+* Eine ausführliche Dokumentation finden Sie `lokal vorinstalliert <http://localhost/cesium/>`_.

--- a/en/presentation/abstract.txt
+++ b/en/presentation/abstract.txt
@@ -16,7 +16,7 @@ http:///livedvd/docs/en/presentation/
 
 ================================================================================
 
-:Title: Lightening Overview of the best Geospatial Open Source
+:Title: Lightning Overview of the best Geospatial Open Source
 
 :Description:
 

--- a/en/quickstart/gdal_quickstart.rst
+++ b/en/quickstart/gdal_quickstart.rst
@@ -18,7 +18,7 @@ You will need nothing but a terminal for this quickstart. If you want to
 visualize the results, you can use one of the Desktop GIS Software
 applications on OSGeo-Live like :doc:`../overview/qgis_overview`. 
 
-This Quick Start is devided in two parts GDAL (raster data) and OGR
+This Quick Start is divided into two parts: GDAL (raster data) and OGR
 (vector data). We will start with GDAL.
 
 This Quick Start describes how to:
@@ -57,7 +57,7 @@ You will then find a NaturalEarth Raster file and a .tfw World-file at:
  ls /home/user/gdal_natural_earth/HYP_50M_SR_W.*
 
 
-.. tip:: Open the file with a Desktop GIS like QGIS. And have a look.
+.. tip:: Open the file with a Desktop GIS like QGIS, and have a look.
 
 Get information about the raster data with gdalinfo
 ================================================================================
@@ -274,7 +274,7 @@ Get to know OGR
   cd /home/user/gdal_natural_earth/
 
 
-.. tip:: Open the shape file with a Desktop GIS like QGIS. And have a look.
+.. tip:: Open the shape file with a Desktop GIS like QGIS, and have a look.
 
 
 Get information about the vector data with ogrinfo

--- a/en/quickstart/leaflet_quickstart.rst
+++ b/en/quickstart/leaflet_quickstart.rst
@@ -6,7 +6,7 @@
 Leaflet Quickstart
 ********************************************************************************
 
-Leaflet is an JavaScript library for browser based, mobile-friendly, interactive maps.  It is light weight, yet has all the features most developers ever need for online maps. Leaflet is designed with simplicity, performance and usability in mind.
+Leaflet is a JavaScript library for browser-based, mobile-friendly, interactive maps.  It is lightweight, yet has all the features most developers ever need for online maps. Leaflet is designed with simplicity, performance and usability in mind.
 
 .. contents:: Contents
 
@@ -22,7 +22,7 @@ View the example_
 
 Preparing your page
 ===================
-Before writing any code for the map, you need to do the following prerpation steps on your page:
+Before writing any code for the map, you need to do the following preparation steps on your page:
 
 * Include Leaflet CSS files in the head section of your document
 
@@ -147,7 +147,7 @@ Every time something happens in Leaflet, e.g. user clicks on a marker or map zoo
 
 Each object has its own set of events - see documentation_ for details. The first argument of the listener function is an event object - it contains useful information about the event that happened. For example, map click event object (e in the example above) has latlng property which is a location at which the click occured.
 
-Lets improve our example by using a popup instead of an alert:
+Let's improve our example by using a popup instead of an alert:
 
 .. code-block:: javascript
 

--- a/en/quickstart/mapbender_quickstart.rst
+++ b/en/quickstart/mapbender_quickstart.rst
@@ -114,7 +114,7 @@ Create a new application by providing basic information about your application. 
 
 #. define a title and description for your application
 
-#. define an URL title which will be used in the URL to open te application. It can be the same as the title
+#. define an URL title which will be used in the URL to open the application. It can be the same as the title
 
 #. upload an image file as screenshot for the application overview
 
@@ -145,7 +145,7 @@ You can delete an application from the menu item :menuselection:`Applications` w
 Export / Import applications and sources
 ================================================================================
 
-You can export applications as JSON or YAML with :menuselection:`Applications --> Export`. You can chose one or more applications to export and you can also export the sources which are published in the applications.
+You can export applications as JSON or YAML with :menuselection:`Applications --> Export`. You can choose one or more applications to export and you can also export the sources which are published in the applications.
 
   .. image:: /images/screenshots/800x600/mapbender3_application_export.png
      :scale: 70 %
@@ -189,7 +189,7 @@ A WMS returns an XML-file when the getCapabilities document is requested. This i
 
 #. Hit **Load** to load the Service to the repository.
 
-#. After successfull registration of the service Mapbender will display an overview on the information that was provided by the service.
+#. After successful registration of the service Mapbender will display an overview on the information that was provided by the service.
 
   .. image:: /images/screenshots/800x600/mapbender3_wms_load.png
      :scale: 70 %
@@ -208,7 +208,7 @@ https://osm-demo.wheregroup.com/service
 
 Add Service to Application
 ================================================================================
-After the successfull upload of a WMS you want to add your WMS to an application.
+After the successful upload of a WMS you want to add your WMS to an application.
 
 #. Choose :menuselection:`Applications --> edit-Button --> Layers --> Edit-Button`. 
 
@@ -246,7 +246,7 @@ Service configuration
 * basesource
 * proxy - if active the service will be requested by Mapbender and not directly
 * transparency - Standard ist aktiviert, deaktiviert wird der Dienst ohne transparenten Hintergrund angefordert (getMap-Request mit TRANSPARENT=FALSE)
-* tiled - you can request a WMS in tiles, default is not tiled (may be a good choice if you map is very big an the WMS service does not support the width/height)
+* tiled - you can request a WMS in tiles, default is not tiled (may be a good choice if your map is very big and the WMS service does not support the width/height)
 * BBOX factor
 * tile buffer
 


### PR DESCRIPTION
Again, most of these are minor one-character or one-word typo fixes.
There is still one odd sentence in the gdal quickstart: "This is because the edges at the pole
can't be reprojected gdalwarp does not read all the data" but the sentence has been like that for years.  It seems like there is a word or three missing there.