### PR TITLE
Forvicky

### DIFF
--- a/en/overview/josm_overview.rst
+++ b/en/overview/josm_overview.rst
@@ -1,7 +1,7 @@
 :Author: OSGeo-Live
 :Author: Javier Sanchez, GeoNaTec
 :Reviewer: Cameron Shorter, Jirotech
-:Version: osgeo-live6.5
+:Version: osgeo-live11.0
 :License: Creative Commons Attribution 3.0 Unported (CC BY 3.0)
 
 .. image:: /images/project_logos/logo-josm.png

--- a/en/overview/josm_overview.rst
+++ b/en/overview/josm_overview.rst
@@ -83,6 +83,6 @@ Details
 Quickstart
 --------------------------------------------------------------------------------
  
-* :doc:`Quickstart documentation <../quickstart/josmeditor_quickstart>`
+* :doc:`Quickstart documentation <../quickstart/josm_quickstart>`
 
 

--- a/en/overview/overview.rst
+++ b/en/overview/overview.rst
@@ -71,7 +71,7 @@ Navigation and Maps
 * :doc:`marble_overview` - [:doc:`QuickStart <../quickstart/marble_quickstart>`] - Virtual Globe
 * :doc:`osm_overview` - [:doc:`QuickStart <../quickstart/osm_quickstart>`] - OpenStreetMap Tools
 * :doc:`ideditor_overview` - [:doc:`QuickStart <../quickstart/ideditor_quickstart>`] - OpenStreetMap Web Editor
-* :doc:`josm_overview` - [:doc:`QuickStart <../quickstart/josmeditor_quickstart>`] - OpenStreetMap Desktop Editor
+* :doc:`josm_overview` - [:doc:`QuickStart <../quickstart/josm_quickstart>`] - OpenStreetMap Desktop Editor
 * :doc:`opencpn_overview` - [:doc:`QuickStart <../quickstart/opencpn_quickstart>`] - Marine GPS Chartplotter
 
 Spatial Tools

--- a/en/quickstart/ideditor_quickstart.rst
+++ b/en/quickstart/ideditor_quickstart.rst
@@ -1,7 +1,7 @@
 :Source: https://github.com/hotosm/learnosm/blob/gh-pages/_posts/en/0200-12-23-id-editor.md
 :Source Reviewed: 2016-03-30  
 :Author: Nick Allen
-:Version: osgeo-live10.5
+:Version: osgeo-live 11
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 :Reviewer: Cameron Shorter (transposed from source)
 

--- a/en/quickstart/ideditor_quickstart.rst
+++ b/en/quickstart/ideditor_quickstart.rst
@@ -1,9 +1,9 @@
 :Source: https://github.com/hotosm/learnosm/blob/gh-pages/_posts/en/0200-12-23-id-editor.md
 :Source Reviewed: 2016-03-30  
-:Author: Cameron Shorter (transposed from source)
+:Author: Nick Allen
 :Version: osgeo-live10.5
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
-:Reviewer: 
+:Reviewer: Cameron Shorter (transposed from source)
 
 ********************************************************************************
 The iD Editor

--- a/en/quickstart/josm_quickstart.rst
+++ b/en/quickstart/josm_quickstart.rst
@@ -65,7 +65,6 @@ Learn Basic Drawing with JOSM
 .. image:: /images/screenshots/1024x768/josm_sample-file.png
    :alt: Sample file
 
-   Sample file
 
 -  You will use these data in order to try various editing techniques.
    *You must however never upload these fictitious data to the
@@ -86,7 +85,6 @@ Basic Operations
 .. image:: /images/screenshots/1024x768/josm_scale-bar.png
    :alt: Scale bar
 
-   Scale bar
 
 -  Look at the sample map. There a few different types of objects here.
    There is a river, a forest, some buildings, several roads, and a
@@ -160,7 +158,6 @@ Drawing
 .. image:: /images/screenshots/1024x768/josm_select-tool.png
    :alt: Select tool
 
-   Select tool
 
 -  Before you draw, you need to make sure that nothing is selected.
    Click in the black space on the map, where it is empty, to make sure
@@ -170,7 +167,6 @@ Drawing
 .. image:: /images/screenshots/1024x768/josm_draw-tool.png
    :alt: Draw tool
 
-   Draw tool
 
 -  Find an empty area on the map, and double-click with your mouse. This
    will draw a single point.
@@ -192,7 +188,6 @@ Add Presets
 .. image:: /images/screenshots/1024x768/josm_select-tool.png
    :alt: Select tool
 
-   Select tool
 
 -  Select one of the objects that you drew with the Draw tool. On the
    top menu, click “Presets”. Move your mouse through the sub-menu to

--- a/en/quickstart/josm_quickstart.rst
+++ b/en/quickstart/josm_quickstart.rst
@@ -1,9 +1,9 @@
 :Source: https://github.com/hotosm/learnosm/blob/gh-pages/_posts/en/1900-12-21-start-josm.md
 :Source Reviewed: 2016-03-30  
-:Author: Cameron Shorter (transposed from source)
+:Author: Nick Allen
 :Version: osgeo-live10.5
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
-:Reviewer: 
+:Reviewer: Cameron Shorter (transposed from source)
 
 ********************************************************************************
 JOSM Quickstart

--- a/en/quickstart/josm_quickstart.rst
+++ b/en/quickstart/josm_quickstart.rst
@@ -1,7 +1,7 @@
 :Source: https://github.com/hotosm/learnosm/blob/gh-pages/_posts/en/1900-12-21-start-josm.md
 :Source Reviewed: 2016-03-30  
 :Author: Nick Allen
-:Version: osgeo-live10.5
+:Version: osgeo-live 11
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 :Reviewer: Cameron Shorter (transposed from source)
 


### PR DESCRIPTION
@kalxas 
Merge this one first, before doing PR #255 

This fixes:
errors created because "figure" command was change to "image" command.
the file name was changed from josmeditor to josm but the links that point to it were not changed.
