### PR TITLE
Showing size of html

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
   #- cmake -DHTML=ON -@OSGeoLiveDoc_DEBUG=ON ..
   #- make html
   - make html SPHINXOPTS=" -v"
+  - du -ch _build/html
   - make small SPHINXOPTS=" -v"
 
 #after_script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,9 @@ script:
   #- make html
   - make html SPHINXOPTS=" -v"
   - du -ch _build/html
+  - make clean
   - make small SPHINXOPTS=" -v"
+  - du -ch _build/html
 
 #after_script: 
 


### PR DESCRIPTION
@kalxas 
Added a command to travis so that the size of the directory `_build/html/` can be viewed.

For example:

Size of html directory when all languages are processed: 225 MB
https://travis-ci.org/cvvergara/OSGeoLive-doc/builds/251614245#L8404

Please merge this PR, before I make some PR to try to lower the size of the html directory .
So that you can review the changes on files & size.
Thanks