### PR TITLE
Ignore id language

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TMP           = /tmp/osgeolive_make
 #LANGUAGES     = ca de el en es hu id it fr ja ko pl ru zh
 #TRANSLATIONS  = ca de el es hu id it fr ja ko pl ru zh
 LANGUAGES     = $(shell ls -d [a-z][a-z])
-TRANSLATIONS  = $(shell echo $(LANGUAGES) | sed -e "s/en //")
+TRANSLATIONS  = $(shell echo $(LANGUAGES) | sed -e "s/en //" | sed -e "s/id //")
 PDF_LANG      = en
 START_DIR     = $(shell pwd)
 

--- a/conf.py
+++ b/conf.py
@@ -75,7 +75,7 @@ today_fmt = '%B %d, %Y'
 # for source files.
 exclude_patterns = [ '_build/*',
 	 'id/*',
-	 'retired_docs' ]
+	 'retired_docs/*' ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/conf.py
+++ b/conf.py
@@ -73,7 +73,9 @@ today_fmt = '%B %d, %Y'
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.
-exclude_trees = ['_build']
+exclude_patterns = [ '_build/*',
+	 'id/*',
+	 'retired_docs' ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None


### PR DESCRIPTION

Menu does not have `id` language
http://adhoc.osgeo.osuosl.org/livedvd/docs/en/index.html


My guess is because only 4 files have being translated only
https://github.com/OSGeo/OSGeoLive-doc/tree/master/id


But the `id` language is still processed
http://adhoc.osgeo.osuosl.org/livedvd/docs/id/index.html
http://adhoc.osgeo.osuosl.org/livedvd/docs/id/overview/qgis_overview.html

Each language takes around 3MB, so not processing `id`,  saves around 3MB
