### PR TITLE
removing _sources directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ sphinxbuild: link_to_en_docs licenses.csv
 fix_header_links: sphinxbuild
 	# Correct relative links for the headers for the top level directory
 	rm -fr $(TMP)
+	rm -fr $(BUILDDIR)/html/_sources
 	for FILE in $(BUILDDIR)/html/*/*.html ; do \
 	  for ITEM in \
 	    contact.html \


### PR DESCRIPTION
Sphinx leaves a `_sources` directory by default, that is useful when there is a button that display the "source" file which is a "copy" of the original `rst` file.

But there is no such button on the documentation.
But the directory takes around 17MB
https://travis-ci.org/OSGeo/OSGeoLive-doc/builds/251673072#L7846
Of useless info like:
http://adhoc.osgeo.osuosl.org/livedvd/docs/_sources/zh/quickstart/grass_quickstart.txt

Size analysis of this PR
https://travis-ci.org/cvvergara/OSGeoLive-doc/builds/251742841#L7872