### PR TITLE
removing the gray background and border on local contents

### DIFF
--- a/themes/overview/static/sphinxdoc.css
+++ b/themes/overview/static/sphinxdoc.css
@@ -254,7 +254,7 @@ div.quotebar {
 }
 
 div.topic {
-    background-color: #f8f8f8;
+    border: 0;
 }
 
 table {


### PR DESCRIPTION
Because of many factors like: screen size, length of test on the introduction of the quickstart, size of logos, sometimes the logos get a strange change of background.

![image](https://user-images.githubusercontent.com/5035290/27995987-cac016dc-649d-11e7-88e5-1adc4f0e81ac.png)

This PR deletes the grey background an border of the table of contents of the quickstarts.
The logos don't get scrambled.

![image](https://user-images.githubusercontent.com/5035290/27996007-15abd014-649e-11e7-8e95-303573c6b245.png)
