### PR TITLE
Update second image on 52nSOS_overview.rst

### DIFF
--- a/ca/overview/52nSOS_overview.rst
+++ b/ca/overview/52nSOS_overview.rst
@@ -22,7 +22,7 @@ així com les que hagin estat capturades tant per sensors in-situ com remots. El
 de tipus molt diferents, com per exemple una càmera digital en un satèl·lit o 
 bé un dispositiu per mesurar el cabdal d'un riu. 
 
-.. image:: /images/screenshots/1024x768/52n_sos_test_client_v1_0_0_GetCapabilities.png
+.. image:: /images/screenshots/1024x768/52n_sos_overview.png
   :scale: 100 %
   :alt: captura de pantalla d'un client SOS
   :align: right

--- a/es/overview/52nSOS_overview.rst
+++ b/es/overview/52nSOS_overview.rst
@@ -20,7 +20,7 @@ Web Service
 El :doc:`Servicio de Observación de Sensores (SOS) <../standards/sos_overview>` 
 de 52ºNorth puede leer y guardar datos actuales o archivados de sensores remotos in-situ. Un sensor puede ser una cámara de un satélite o el medidor de caudal de un río.
  
-.. image:: /images/screenshots/1024x768/52n_sos_test_client_v1_0_0_GetCapabilities.png
+.. image:: /images/screenshots/1024x768/52n_sos_overview.png
   :scale: 100 %
   :alt: Pantallazos de un cliente de pruebas
   :align: right

--- a/fr/overview/52nSOS_overview.rst
+++ b/fr/overview/52nSOS_overview.rst
@@ -17,7 +17,7 @@ Service Web
 
 The :doc:`Sensor Observation Service (SOS) <../standards/sos_overview>` de 52°North supporte la lecture en directe et la capture de données compressées depuis des capteurs in-situ et distants. Un capteur peut aussi bien être une caméra sur un satellite qu'une échelle pour mesurer le niveau d'eau dans un courant.
  
-.. image:: /images/screenshots/1024x768/52n_sos_test_client_v1_0_0_GetCapabilities.png
+.. image:: /images/screenshots/1024x768/52n_sos_overview.png
   :scale: 60 %
   :alt: Capture d'écran du client de test de 52°North SOS version 1.0.0
   :align: right

--- a/ko/overview/52nSOS_overview.rst
+++ b/ko/overview/52nSOS_overview.rst
@@ -17,7 +17,7 @@ Web Service
 
 The 52°North :doc:`Sensor Observation Service (SOS) <../standards/sos_overview>` supports reading of live and archived data captured by in-situ and remote sensors. A sensor may be a camera on a satellite or a water level meter in a stream.
  
-.. image:: /images/screenshots/1024x768/52n_sos_test_client_v1_0_0_GetCapabilities.png
+.. image:: /images/screenshots/1024x768/52n_sos_overview.png
   :scale: 60 %
   :alt: screenshot of 52°North SOS test client version 1.0.0
   :align: right

--- a/pl/overview/52nSOS_overview.rst
+++ b/pl/overview/52nSOS_overview.rst
@@ -23,7 +23,7 @@ pozwala na czytanie zarówno archiwalnych, jak i danych odbieranych bezpośredni
 przez sensory zdalne bądź in-situ. Sensorem może być kamera znajdująca się 
 na satelicie lub wodomierz w strumieniu.
  
-.. image:: /images/screenshots/1024x768/52n_sos_test_client_v1_0_0_GetCapabilities.png
+.. image:: /images/screenshots/1024x768/52n_sos_overview.png
   :scale: 60 %
   :alt: screenshot of 52°North SOS test client version 1.0.0
   :align: right

--- a/ru/overview/52nSOS_overview.rst
+++ b/ru/overview/52nSOS_overview.rst
@@ -20,7 +20,7 @@
 с локальных и удаленных сенсоров. Сенсором может выступать камера на спутнике 
 или измеритель уровня воды в реке.
 
-.. image:: /images/screenshots/1024x768/52n_sos_test_client_v1_0_0_GetCapabilities.png
+.. image:: /images/screenshots/1024x768/52n_sos_overview.png
   :scale: 60 %
   :alt: снимок экрана тестового клиента 52°North SOS версии 1.0.0
   :align: right

--- a/zh/overview/52nSOS_overview.rst
+++ b/zh/overview/52nSOS_overview.rst
@@ -18,7 +18,7 @@ Web服务
 52°North :doc:`Sensor Observation Service (SOS) <../standards/sos_overview>` 
 支持访问来自当地与远程传感器实时获取或者历史存档的数据。传感器可以是安装在卫星上的照相机或者河流里的水位仪。
  
-.. image:: /images/screenshots/1024x768/52n_sos_test_client_v1_0_0_GetCapabilities.png
+.. image:: /images/screenshots/1024x768/52n_sos_overview.png
   :scale: 100 %
   :alt: screenshot of sos test client
   :align: right


### PR DESCRIPTION
Fix error messages during build because of missing image:

> /fr/overview/52nSOS_overview.rst:None: WARNING: image file not readable: images/screenshots/1024x768/52n_sos_test_client_v1_0_0_GetCapabilities.png