### PR TITLE
Add OSGeo logo in otb overview and quickstart

### DIFF
--- a/ca/overview/otb_overview.rst
+++ b/ca/overview/otb_overview.rst
@@ -4,10 +4,17 @@
 :Version: osgeo-live5.5
 :License: Creative Commons Attribution 3.0 Unported (CC BY 3.0)
 
+
 .. image:: /images/project_logos/logo-otb.png
   :alt: project logo
   :align: right
   :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 OTB
 ================================================================================

--- a/de/overview/otb_overview.rst
+++ b/de/overview/otb_overview.rst
@@ -3,10 +3,17 @@
 :Version: osgeo-live8.5
 :License: Creative Commons Attribution 3.0 Unported (CC BY 3.0)
 
+
 .. image:: /images/project_logos/logo-otb.png
   :alt: project logo
   :align: right
   :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 OTB
 ================================================================================

--- a/el/quickstart/otb_quickstart.rst
+++ b/el/quickstart/otb_quickstart.rst
@@ -7,6 +7,13 @@
   :scale: 80 %
   :alt: project logo
   :align: right
+  :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 *********************************
 Εγχειρίδιο Γρήγορης Εκκίνησης OTB

--- a/en/overview/otb_overview.rst
+++ b/en/overview/otb_overview.rst
@@ -3,10 +3,17 @@
 :Version: osgeo-live8.5
 :License: Creative Commons Attribution 3.0 Unported (CC BY 3.0)
 
+
 .. image:: /images/project_logos/logo-otb.png
   :alt: project logo
   :align: right
   :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 OTB
 ================================================================================

--- a/en/quickstart/otb_quickstart.rst
+++ b/en/quickstart/otb_quickstart.rst
@@ -7,6 +7,13 @@
   :scale: 80 %
   :alt: project logo
   :align: right
+  :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 ********************************************************************************
 OTB Quickstart 

--- a/es/overview/otb_overview.rst
+++ b/es/overview/otb_overview.rst
@@ -5,10 +5,17 @@
 :Version: osgeo-live8.5
 :License: Creative Commons Attribution 3.0 Unported (CC BY 3.0)
 
+
 .. image:: /images/project_logos/logo-otb.png
   :alt: project logo
   :align: right
   :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 OTB
 ================================================================================

--- a/es/quickstart/otb_quickstart.rst
+++ b/es/quickstart/otb_quickstart.rst
@@ -8,6 +8,13 @@
   :scale: 80 %
   :alt: project logo
   :align: right
+  :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 ********************************************************************************
 Guía de inicio rápido de OTB 

--- a/fr/overview/otb_overview.rst
+++ b/fr/overview/otb_overview.rst
@@ -4,9 +4,15 @@
 :License: Creative Commons Attribution 3.0 Unported (CC BY 3.0)
 
 .. image:: /images/project_logos/logo-otb.png
-  :alt: Logo du projet
+  :alt: project logo
   :align: right
   :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 OTB
 ================================================================================

--- a/it/overview/otb_overview.rst
+++ b/it/overview/otb_overview.rst
@@ -9,6 +9,12 @@
   :align: right
   :target: http://www.orfeo-toolbox.org/
 
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
+
 OTB
 ================================================================================
 

--- a/it/quickstart/otb_quickstart.rst
+++ b/it/quickstart/otb_quickstart.rst
@@ -8,6 +8,13 @@
   :scale: 80 %
   :alt: project logo
   :align: right
+  :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 ********************************************************************************
 Guida rapida su OTB

--- a/ja/overview/otb_overview.rst
+++ b/ja/overview/otb_overview.rst
@@ -8,6 +8,12 @@
   :align: right
   :target: http://www.orfeo-toolbox.org/
 
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
+
 OTB
 ================================================================================
 

--- a/ko/overview/otb_overview.rst
+++ b/ko/overview/otb_overview.rst
@@ -8,6 +8,12 @@
   :align: right
   :target: http://www.orfeo-toolbox.org/
 
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
+
 OTB
 ================================================================================
 

--- a/pl/overview/otb_overview.rst
+++ b/pl/overview/otb_overview.rst
@@ -9,6 +9,12 @@
   :align: right
   :target: http://www.orfeo-toolbox.org/
 
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
+
 OTB
 ================================================================================
 

--- a/ru/overview/otb_overview.rst
+++ b/ru/overview/otb_overview.rst
@@ -4,9 +4,15 @@
 :License: Creative Commons Attribution 3.0 Unported (CC BY 3.0)
 
 .. image:: /images/project_logos/logo-otb.png
-  :alt: Лого проекта
+  :alt: project logo
   :align: right
   :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 OTB
 ================================================================================

--- a/ru/quickstart/otb_quickstart.rst
+++ b/ru/quickstart/otb_quickstart.rst
@@ -5,8 +5,15 @@
 
 .. image:: /images/project_logos/logo-otb.png
   :scale: 80 %
-  :alt: Лого проекта
+  :alt: project logo
   :align: right
+  :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 ********************************************************************************
 OTB: начало работы

--- a/zh/overview/otb_overview.rst
+++ b/zh/overview/otb_overview.rst
@@ -9,6 +9,12 @@
   :align: right
   :target: http://www.orfeo-toolbox.org/
 
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
+
 OTB
 ================================================================================
 

--- a/zh/quickstart/otb_quickstart.rst
+++ b/zh/quickstart/otb_quickstart.rst
@@ -7,6 +7,13 @@
   :scale: 80 %
   :alt: project logo
   :align: right
+  :target: http://www.orfeo-toolbox.org/
+
+.. image:: /images/logos/OSGeo_project.png
+  :scale: 100 %
+  :alt: OSGeo Project
+  :align: right
+  :target: http://www.osgeo.org
 
 ********************************************************************************
 OTB 快速入门 


### PR DESCRIPTION
Following Vicky remark on osgeo incubation, I've updated the OSGeo logo in  OTB overview and quickstart (in all available languages)