### PR TITLE
fix python syntax to work with python3 and python2

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -13,7 +13,7 @@
 
 import sys, os
 
-execfile('settings.py')
+exec(open("settings.py").read())
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
this little change allows the sphinx build with python3