### PR TITLE
Fix debian sphinx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ sphinxbuild: link_to_en_docs licenses.csv
 fix_header_links: sphinxbuild
 	# Correct relative links for the headers for the top level directory
 	rm -fr $(TMP)
-	rm -fr $(BUILDDIR)/html/_sources
 	for FILE in $(BUILDDIR)/html/*/*.html ; do \
 	  for ITEM in \
 	    contact.html \

--- a/conf.py
+++ b/conf.py
@@ -176,6 +176,8 @@ html_last_updated_fmt = '%b %d, %Y'
 # Output file base name for HTML help builder.
 htmlhelp_basename = '%sdoc' % project
 
+# Don't copy sources
+html_copy_source = False
 
 # -- Options for LaTeX output --------------------------------------------------
 


### PR DESCRIPTION
Rather than removing the _sources manually, we make sure that they are not generated. This way the debian build still works correctly.