### PR TITLE
converting the qickstart hyperlink references to anonymous hyperlink …

### DIFF
--- a/en/overview/overview.rst
+++ b/en/overview/overview.rst
@@ -11,8 +11,8 @@
    :hidden:
    :glob:
 
-   *_overview
-   ../quickstart/*_quickstart
+   *
+   ../quickstart/*
 
 
 Desktop GIS
@@ -169,43 +169,43 @@ Available in prior OSGeo-Live releases:
 
 |nologo| `OGC Standard descriptions <https://live.osgeo.org/archive/10.5/en/standards/standards.html>`_, not included after OSGeo-Live 10.5
 
-|nologo| `Viking <https://live.osgeo.org/archive/10.5/en/overview/viking_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/viking_quickstart.html>`_] - GPS Data Analysis and Viewer, not included after OSGeo-Live 10.5
+|nologo| `Viking <https://live.osgeo.org/archive/10.5/en/overview/viking_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/viking_quickstart.html>`__] - GPS Data Analysis and Viewer, not included after OSGeo-Live 10.5
 
-|nologo| `Ushahidi <https://live.osgeo.org/archive/10.5/en/overview/ushahidi_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/ushahidi_quickstart.html>`_] - Mapping and Timeline for events, not included after OSGeo-Live 10.5
+|nologo| `Ushahidi <https://live.osgeo.org/archive/10.5/en/overview/ushahidi_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/ushahidi_quickstart.html>`__] - Mapping and Timeline for events, not included after OSGeo-Live 10.5
 
-|nologo| `TinyOWS <https://live.osgeo.org/archive/10.5/en/overview/tinyows_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/tinyows_quickstart.html>`_] - WFS-T Service, not included after OSGeo-Live 10.5
+|nologo| `TinyOWS <https://live.osgeo.org/archive/10.5/en/overview/tinyows_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/tinyows_quickstart.html>`__] - WFS-T Service, not included after OSGeo-Live 10.5
 
-|osgeocommunity| `PyWPS <https://live.osgeo.org/archive/10.5/en/overview/pywps_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/pywps_quickstart.html>`_] - Web Processing Service, not included after OSGeo-Live 10.5
+|osgeocommunity| `PyWPS <https://live.osgeo.org/archive/10.5/en/overview/pywps_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/pywps_quickstart.html>`__] - Web Processing Service, not included after OSGeo-Live 10.5
 
-|nologo| `osgEarth <https://live.osgeo.org/archive/10.5/en/overview/osgearth_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/osgearth_quickstart.html>`_] - 3D Terrain Rendering, not included after OSGeo-Live 10.5
+|nologo| `osgEarth <https://live.osgeo.org/archive/10.5/en/overview/osgearth_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/osgearth_quickstart.html>`__] - 3D Terrain Rendering, not included after OSGeo-Live 10.5
 
-|nologo| `Kosmo Desktop <https://live.osgeo.org/archive/10.5/en/overview/kosmo_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/kosmo_quickstart.html>`_], not included after OSGeo-Live 10.5
+|nologo| `Kosmo Desktop <https://live.osgeo.org/archive/10.5/en/overview/kosmo_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/kosmo_quickstart.html>`__], not included after OSGeo-Live 10.5
 
-|nologo| `WorldWind Java <https://live.osgeo.org/archive/10.5/en/overview/worldwindjava_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/worldwindjava_quickstart.html>`_] - Desktop Virtual Globe, not included after OSGeo-Live 10.5
+|nologo| `WorldWind Java <https://live.osgeo.org/archive/10.5/en/overview/worldwindjava_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/worldwindjava_quickstart.html>`__] - Desktop Virtual Globe, not included after OSGeo-Live 10.5
 
-|nologo| `Iris <https://live.osgeo.org/archive/10.5/en/overview/iris_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/iris_quickstart.html>`_] - Meteorology and Climatology, not included after OSGeo-Live 10.5
+|nologo| `Iris <https://live.osgeo.org/archive/10.5/en/overview/iris_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/iris_quickstart.html>`__] - Meteorology and Climatology, not included after OSGeo-Live 10.5
 
-|nologo| `GeoKettle <https://live.osgeo.org/archive/10.5/en/overview/geokettle_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/geokettle_quickstart.html>`_] - ETL (Extract, Transform and Load) Tool, not included after OSGeo-Live 10.5
+|nologo| `GeoKettle <https://live.osgeo.org/archive/10.5/en/overview/geokettle_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/geokettle_quickstart.html>`__] - ETL (Extract, Transform and Load) Tool, not included after OSGeo-Live 10.5
 
-|nologo| `Sahana <https://live.osgeo.org/archive/10.5/en/overview/sahana_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/sahana_quickstart.html>`_] - Disaster management, not included after OSGeo-Live 10.5
+|nologo| `Sahana <https://live.osgeo.org/archive/10.5/en/overview/sahana_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/sahana_quickstart.html>`__] - Disaster management, not included after OSGeo-Live 10.5
 
-|nologo| `MB System <https://live.osgeo.org/archive/10.5/en/overview/mb-system_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/mb-system_quickstart.html>`_] - Sea Floor Mapping, not included after OSGeo-Live 10.5
+|nologo| `MB System <https://live.osgeo.org/archive/10.5/en/overview/mb-system_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.5/en/quickstart/mb-system_quickstart.html>`__] - Sea Floor Mapping, not included after OSGeo-Live 10.5
 
-|nologo| `Cartaro <https://live.osgeo.org/archive/10.0/en/overview/cartaro_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.0/en/quickstart/cartaro_quickstart.html>`_] - Geospatial CMS, not included after OSGeo-Live 10.0
+|nologo| `Cartaro <https://live.osgeo.org/archive/10.0/en/overview/cartaro_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/10.0/en/quickstart/cartaro_quickstart.html>`__] - Geospatial CMS, not included after OSGeo-Live 10.0
 
-|nologo| `TileMill <https://live.osgeo.org/archive/9.5/en/overview/tilemill_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/9.5/en/quickstart/tilemill_quickstart.html>`_] - Styling and Publishing, not included after OSGeo-Live 9.5
+|nologo| `TileMill <https://live.osgeo.org/archive/9.5/en/overview/tilemill_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/9.5/en/quickstart/tilemill_quickstart.html>`__] - Styling and Publishing, not included after OSGeo-Live 9.5
 
-|nologo| `GpsDrive <https://live.osgeo.org/archive/9.0/en/overview/gpsdrive_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/9.0/en/quickstart/gpsdrive_quickstart.html>`_] - GPS Navigation, not included after OSGeo-Live 9.0
+|nologo| `GpsDrive <https://live.osgeo.org/archive/9.0/en/overview/gpsdrive_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/9.0/en/quickstart/gpsdrive_quickstart.html>`__] - GPS Navigation, not included after OSGeo-Live 9.0
 
-|nologo| `Map Window <https://live.osgeo.org/archive/8.0/en/overview/mapwindow_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/8.0/en/quickstart/mapwindow_quickstart>`_] - Microsoft Windows based Desktop GIS, only available as a Windows installer, not included after OSGeo-Live 8.0
+|nologo| `Map Window <https://live.osgeo.org/archive/8.0/en/overview/mapwindow_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/8.0/en/quickstart/mapwindow_quickstart>`__] - Microsoft Windows based Desktop GIS, only available as a Windows installer, not included after OSGeo-Live 8.0
 
-|osgeoproject| `MapFish <https://live.osgeo.org/archive/7.9/en/overview/mapfish_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/7.9/en/quickstart/mapfish_quickstart.html>`_] - Web Mapping Framework, not included after OSGeo-Live 7.9
+|osgeoproject| `MapFish <https://live.osgeo.org/archive/7.9/en/overview/mapfish_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/7.9/en/quickstart/mapfish_quickstart.html>`__] - Web Mapping Framework, not included after OSGeo-Live 7.9
 
-|nologo| `52NorthWSS <https://live.osgeo.org/archive/6.5/en/overview/52nWSS_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/6.5/en/quickstart/52nWSS_quickstart.html>`_] - Web Security Service, not included after OSGeo-Live 6.5
+|nologo| `52NorthWSS <https://live.osgeo.org/archive/6.5/en/overview/52nWSS_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/6.5/en/quickstart/52nWSS_quickstart.html>`__] - Web Security Service, not included after OSGeo-Live 6.5
 
 |nologo| `Geopublisher <https://live.osgeo.org/archive/6.0/en/overview/52nWSS_overview.html>`_  - Catalogue, not included after OSGeo-Live 6.0
 
 |nologo| `AtlasStyler <https://live.osgeo.org/archive/6.0/en/overview/52nWSS_overview.html>`_ - Style Editor, not included after OSGeo-Live 6.0
 
-|osgeoproject| `MapGuide <https://live.osgeo.org/archive/5.0/en/overview/mapguide_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/5.0/en/quickstart/mapguide_quickstart.html>`_] - Web Service, not included after OSGeo-Live 5.0
+|osgeoproject| `MapGuide <https://live.osgeo.org/archive/5.0/en/overview/mapguide_overview.html>`_ - [`QuickStart <https://live.osgeo.org/archive/5.0/en/quickstart/mapguide_quickstart.html>`__] - Web Service, not included after OSGeo-Live 5.0
 


### PR DESCRIPTION
This removes the sphinx errors:
https://travis-ci.org/OSGeo/OSGeoLive-doc#L7205

Anonymous hyper link are with two underscores.

I also simplified the glob