### PR TITLE
Remove python imaging, replaced by pil (already in deps)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Johan Van de Wauw <johan.vandewauw@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), 
                python-sphinx,
-               python-imaging,
                python-pil,
                pngquant
 Standards-Version: 3.9.6


### PR DESCRIPTION
python-imaging is dropped in bionic