### PR TITLE
download.rst - change link to always use the version variable

### DIFF
--- a/doc/download.rst
+++ b/doc/download.rst
@@ -7,7 +7,7 @@ Download
 ================================================================================
 
 The latest stable release is |osgeolive-version| and can be downloaded from:
-https://sourceforge.net/projects/osgeo-live/files/11.0/
+https://sourceforge.net/projects/osgeo-live/files/|osgeolive-version|/
 
 Picking the right image for you:
 


### PR DESCRIPTION
* integrate the version variable in the download link |osgeolive-version|
* https://sourceforge.net/projects/osgeo-live/files/11.0/ -> new https://sourceforge.net/projects/osgeo-live/files/|osgeolive-version|/