### PR TITLE
GRASS web site URLs updated

### DIFF
--- a/doc/overview/grass_overview.rst
+++ b/doc/overview/grass_overview.rst
@@ -3,9 +3,9 @@
 :Reviewer: Markus Neteler
 :Reviewer: Angelos Tzotsos, OSGeo
 :Reviewer: Luca Delucchi
-:Version: osgeolive11.0
+:Version: osgeolive13.0
 :License: Creative Commons Attribution 3.0 Unported (CC BY 3.0)
-:Copyright: 2011-2015 by The OSGeo Foundation
+:Copyright: 2011-2019 by The OSGeo Foundation
 
 @LOGO_grass@
 @OSGEO_KIND_grass@
@@ -45,22 +45,22 @@ used both for batch data processing on massively-parallel supercomputers
 as well as a handy desktop GIS for handheld PDAs or netbooks.
 
 
-.. _GRASS GIS: http://grass.osgeo.org
+.. _GRASS GIS: https://grass.osgeo.org
 
 @SCREENSHOT_grass@
 
 Core Features
 --------------------------------------------------------------------------------
 
-* You name it, there's a `tool for it <http://grass.osgeo.org/grass74/manuals/keywords.html>`_.
-* Explore the `screenshot collection <http://grass.osgeo.org/screenshots/>`_.
+* You name it, there's a `tool for it <https://grass.osgeo.org/grass76/manuals/keywords.html>`_.
+* Explore the `screenshot collection <https://grass.osgeo.org/screenshots/>`_.
 
 Details
 --------------------------------------------------------------------------------
 
-**Website:** http://grass.osgeo.org
+**Website:** https://grass.osgeo.org
 
-**Licence:** GNU General Public License (GPL) version 2
+**Licence:** GNU General Public License (GPL) version 2+
 
 **Software Version:** |version-grass|
 
@@ -68,7 +68,7 @@ Details
 
 **API Interfaces:** C, Python, Bourne Shell
 
-**Support:** http://grass.osgeo.org/support/
+**Support:** https://grass.osgeo.org/support/
 
 
 @QUICKSTART_grass@

--- a/doc/quickstart/grass_quickstart.rst
+++ b/doc/quickstart/grass_quickstart.rst
@@ -3,7 +3,7 @@
 :Reviewer: Angelos Tzotsos, OSGeo
 :Version: osgeolive11.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)
-:Copyright: 2011-2015 by The OSGeo Foundation
+:Copyright: 2011-2019 by The OSGeo Foundation
 
 @LOGO_grass@
 @OSGEO_KIND_grass@
@@ -334,7 +334,7 @@ While not covered here, you may like to experiment with the
 Cartographic Composer and object-oriented Graphical Modelling Tool (offers
 export to Python); you'll find icons to launch them on the lower row of
 icons in the `Layer Manager` window. Further details can be found in
-the `wxGUI <https://grass.osgeo.org/grass74/manuals/wxGUI.html>`_ help pages.
+the `wxGUI <https://grass.osgeo.org/grass76/manuals/wxGUI.html>`_ help pages.
 
 The wxGUI is written in Python, and if you're a fan of Python programming
 there are a number of great tools and an API available to you. In the bottom
@@ -366,9 +366,9 @@ prompt to leave the GIS environment.
 
 Further reading
 ================================================================================
-* Visit the GRASS GIS website at `http://grass.osgeo.org <http://grass.osgeo.org>`_
-* Visit the GRASS GIS Wiki help site at `http://grasswiki.osgeo.org/wiki/ <http://grasswiki.osgeo.org/wiki/>`_
-* More tutorials and overviews can be found `here <http://grasswiki.osgeo.org/wiki/GRASS_Help#Getting_Started>`_.
-* A `synopsis of the GRASS GIS modules <https://grass.osgeo.org/grass74/manuals/full_index.html>`_
+* Visit the GRASS GIS website at `https://grass.osgeo.org <https://grass.osgeo.org>`_
+* Visit the GRASS GIS Wiki help site at `https://grasswiki.osgeo.org/wiki/ <https://grasswiki.osgeo.org/wiki/>`_
+* More tutorials and overviews can be found `here <https://grasswiki.osgeo.org/wiki/GRASS_Help#Getting_Started>`_.
+* A `synopsis of the GRASS GIS modules <https://grass.osgeo.org/grass76/manuals/full_index.html>`_
 * If the 400 GIS modules which come with GRASS aren't enough for you have a look at the many contributed
-  add-ons at `http://grass.osgeo.org/grass74/manuals/addons/ <http://grass.osgeo.org/grass74/manuals/addons/>`_
+  add-ons at `https://grass.osgeo.org/grass7/manuals/addons/ <https://grass.osgeo.org/grass7/manuals/addons/>`_

--- a/doc/win_installers.rst
+++ b/doc/win_installers.rst
@@ -14,7 +14,7 @@ vcredist_x86.exe is the  Runtime from Microsoft, it is required for many of the 
 * http://download.osgeo.org/osgeo4w/osgeo4w-setup.exe
 * http://qgis.org/downloads/QGIS-OSGeo4W-1.8.0-2-Setup.exe
 * http://home.gdal.org/tmp/vcredist_x86.exe
-* http://grass.osgeo.org/grass70/binary/mswindows/native/
+* http://grass.osgeo.org/grass76/binary/mswindows/native/
 * http://download.osgeo.org/livedvd/data/gpsbabel/GPSBabel-1.4.4-Setup.exe
 * http://github.com/downloads/mapbox/tilemill/TileMill-v0.10.1-Setup.exe
 * http://gpsvp.googlecode.com/files/gpsVPxp_0.4.24.zip


### PR DESCRIPTION
- update to GRASS GIS 7.6 URLs
- use of https
- addons: use generic link