### PR TITLE
change font-family for OSGeoLive Presentation

### DIFF
--- a/doc/_static/reveal.js/css/theme/serif.css
+++ b/doc/_static/reveal.js/css/theme/serif.css
@@ -15,7 +15,7 @@ body {
   background-color: #F0F1EB; }
 
 .reveal {
-  font-family: "Palatino Linotype", "Book Antiqua", Palatino, FreeSerif, serif;
+  font-family: "Miriam Libre","Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size: 36px;
   font-weight: normal;
   color: #000; }
@@ -41,7 +41,7 @@ body {
 .reveal h6 {
   margin: 0 0 20px 0;
   color: #383D3D;
-  font-family: "Palatino Linotype", "Book Antiqua", Palatino, FreeSerif, serif;
+  font-family: "Miriam Libre","Helvetica Neue",Helvetica,Arial,sans-serif;
   font-weight: normal;
   line-height: 1.2;
   letter-spacing: normal;


### PR DESCRIPTION
from: "Palatino Linotype", "Book Antiqua", Palatino, FreeSerif, serif;

to: "Miriam Libre","Helvetica Neue",Helvetica,Arial,sans-serif;