### PR TITLE
Update contact us details

### DIFF
--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -3,7 +3,7 @@ Contact Us
 
 OSGeoLive development is coordinated via email and internet chat
 (IRC) as detailed on the
-`OSGeo Wiki <http://wiki.osgeo.org/wiki/OSGeoLive#Contact_Us>`_.
+`OSGeoLive Wiki <https://trac.osgeo.org/osgeolive#Communication>`_.
 
 Disclaimer
 ================================================================================


### PR DESCRIPTION
The first link  in the contact us section [1] send to OSGeoLive Wiki [2]. It contents only a link that send to the trac wiki [3] 

I suggest that it should refers to the trac page (or nothing) as the contact us page on the documentation [3] will be translated and be revised at each release.

This is as been spotted with the help of aeylinen on Transifex (Thanks)

[1] https://live.osgeo.org/en/contact.html
[2] http\://wiki.osgeo.org/wiki/OSGeoLive#Contact_Us
[3] https://trac.osgeo.org/osgeolive#Communication