### PR TITLE
Reviewed cesium QuickStart

### DIFF
--- a/doc/quickstart/cesium_quickstart.rst
+++ b/doc/quickstart/cesium_quickstart.rst
@@ -11,7 +11,7 @@
 ********************************************************************************
 @NAME_cesium@ Quickstart
 ********************************************************************************
-Cesium is a JavaScript library for creating 3D globes and 2D maps in a web browser without any plugins. It uses WebGL for hardware-accelerated graphics, and is cross-platform, cross-browser, and tuned for dynamic-data visualization.
+Cesium is a JavaScript library for creating 3D globes and 2D maps in a web browser without any plugins. It uses WebGL for hardware-accelerated graphics, and is cross-platform, cross-browser, and tuned for time-dynamic data visualization.
 
 This guide shows how to use the Cesium with the 3D (Globe), 2.5D (Columbus View) and 2D (map).
 
@@ -57,10 +57,12 @@ Click on the last icon and select a type of image service.  Here the Natural Ear
 
 What next?
 ==========
-* There are `video tutorials <https://www.youtube.com/playlist?list=PLBk_Dtk-_Tlm4STvXKFEdfUWylPemo-9V>`_.
+* Watch our `video tutorials <https://www.youtube.com/playlist?list=PLBk_Dtk-_Tlm4STvXKFEdfUWylPemo-9V>`_.
 
-* Web based tutorials are `here <http://cesiumjs.org/tutorials.html>`_.
+* Read our written `tutorials <http://cesium.com/docs>`_.
 
-* You can develop some quick applications using the Sandcastle website by following this `link <http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Custom%20DataSource.html&label=Tutorials>`_.
+* You can develop some quick applications using the `Sandcastle website <https://sandcastle.cesium.com/index.html>`_. Sandcastle is generally one of the best ways to learn about Cesium, and all the code examples are useful for this purpose.
 
-* In-depth documentation is available `locally <http://localhost/cesium/>`_.
+* The `Cesium Forum <https://groups.google.com/forum/#!forum/cesium-dev>`_ is a great place to search for answers to common questions, and to raise questions that haven't been asked before.
+
+* In-depth documentation is available `locally <http://localhost/cesium/>`_ on the OSGeoLive package.

--- a/doc/quickstart/cesium_quickstart.rst
+++ b/doc/quickstart/cesium_quickstart.rst
@@ -1,6 +1,7 @@
 :Author: Balasubramaniam Natarajan
 :Reviewer: Cameron Shorter, Jirotech
 :Reviewer: Angelos Tzotsos, OSGeo
+:Reviewer: Felicity Brand (Google Season of Docs 2019)
 :Version: osgeolive11.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
@@ -10,24 +11,28 @@
 ********************************************************************************
 @NAME_cesium@ Quickstart
 ********************************************************************************
-This document shows how to use the Cesium with the 3D (Globe), 2.5D (Columbus View) and 2D (map).
+Cesium is a JavaScript library for creating 3D globes and 2D maps in a web browser without any plugins. It uses WebGL for hardware-accelerated graphics, and is cross-platform, cross-browser, and tuned for dynamic-data visualization.
 
-Starting Cesium
+This guide shows how to use the Cesium with the 3D (Globe), 2.5D (Columbus View) and 2D (map).
+
+.. contents:: Contents
+
+Start @NAME_cesium@ 
 ================================================================================
 
 Open the browser and point it to http://localhost/cesium/Apps/HelloWorld.html
 
-Searching for locations
+Search for a location
 ================================================================================
-You can click on the magnifying glass and type in the location you are looking for.  In the following display, we look for India.
+Click on the magnifying glass and type in the location you are looking for. In the following display, we look for India.
 
 .. image:: /images/projects/cesium/cesium_1_SearchingLocation.png
   :scale: 70 %
   :alt: Cesium Searching Location
 
-Switching between 3D, 2.5D and 2D
+Switch between 3D, 2.5D and 2D
 ================================================================================
-You can click on the wire framed globe icon to select your preferred view.  Here the 2.5D Columbus view has been selected.
+Click on the wire framed globe icon to select your preferred view.  Here the 2.5D Columbus view has been selected.
 
 .. image:: /images/projects/cesium/cesium_2_2253d.png
   :scale: 70 %
@@ -39,9 +44,9 @@ Now the 2D map is selected.
   :scale: 70 %
   :alt: Cesium 2D map
 
-Selecting the Image layer
+Select the Image layer
 ================================================================================
-We can click on the last icon and select the type of image service we want.  Here the Natural Earth II is selected and you can see how the map's image layer has changed.
+Click on the last icon and select a type of image service.  Here the Natural Earth II is selected and you can see how the map's image layer has changed.
 
 .. image:: /images/projects/cesium/cesium_4_Layer.png
   :scale: 70 %

--- a/doc/quickstart/cesium_quickstart.rst
+++ b/doc/quickstart/cesium_quickstart.rst
@@ -2,7 +2,7 @@
 :Reviewer: Cameron Shorter, Jirotech
 :Reviewer: Angelos Tzotsos, OSGeo
 :Reviewer: Felicity Brand (Google Season of Docs 2019)
-:Version: osgeolive11.0
+:Version: osgeolive13.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
 @LOGO_cesium@
@@ -16,14 +16,15 @@ Cesium is a JavaScript library for creating 3D globes and 2D maps in a web brows
 This guide shows how to use the Cesium with the 3D (Globe), 2.5D (Columbus View) and 2D (map).
 
 .. contents:: Contents
+   :local:
 
-Start @NAME_cesium@ 
-================================================================================
+Start Cesium 
+============
 
 Open the browser and point it to http://localhost/cesium/Apps/HelloWorld.html
 
 Search for a location
-================================================================================
+=====================
 Click on the magnifying glass and type in the location you are looking for. In the following display, we look for India.
 
 .. image:: /images/projects/cesium/cesium_1_SearchingLocation.png
@@ -31,7 +32,7 @@ Click on the magnifying glass and type in the location you are looking for. In t
   :alt: Cesium Searching Location
 
 Switch between 3D, 2.5D and 2D
-================================================================================
+==============================
 Click on the wire framed globe icon to select your preferred view.  Here the 2.5D Columbus view has been selected.
 
 .. image:: /images/projects/cesium/cesium_2_2253d.png
@@ -45,7 +46,7 @@ Now the 2D map is selected.
   :alt: Cesium 2D map
 
 Select the Image layer
-================================================================================
+======================
 Click on the last icon and select a type of image service.  Here the Natural Earth II is selected and you can see how the map's image layer has changed.
 
 .. image:: /images/projects/cesium/cesium_4_Layer.png
@@ -54,8 +55,8 @@ Click on the last icon and select a type of image service.  Here the Natural Ear
 
 .. TBD: There is room here for a couple more examples.
 
-What Next?
-================================================================================
+What next?
+==========
 * There are `video tutorials <https://www.youtube.com/playlist?list=PLBk_Dtk-_Tlm4STvXKFEdfUWylPemo-9V>`_.
 
 * Web based tutorials are `here <http://cesiumjs.org/tutorials.html>`_.


### PR DESCRIPTION
Reviewed as part of the QuickStart project during Google Season of Docs 2019. The aim is consistency across all OSGeoLive QuickStarts.

The document is structured well and only requires minor changes. Consider changing the links in the What Next section to show the URLs explicitly.
@bala150985 Please action comments and suggestions you agree with, and ignore those you don't.

Partner trac ticket link:
https://trac.osgeo.org/osgeolive/ticket/2194

See this page for reference: https://trac.osgeo.org/osgeolive/wiki/How%20to%20document%20the%20quickstart%20file
