### PR TITLE
Reviewed mapcache QuickStart

### DIFF
--- a/doc/quickstart/mapcache_quickstart.rst
+++ b/doc/quickstart/mapcache_quickstart.rst
@@ -1,5 +1,6 @@
 :Author: OSGeoLive
 :Author: Seth Girvin
+:Reviewer: Felicity Brand (Google Season of Docs 2019)
 :Version: osgeolive13.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
@@ -16,7 +17,7 @@ under many different web servers, or as an Apache module. OSGeoLive has MapCache
 This quick start shows how to add a new WMS layer to a MapCache set-up, display the tile service in an OpenLayers web map, and
 seed a tile cache from the command line. 
 
-.. contents:: Quick Start Contents
+.. contents:: Contents
     :local:
     :depth: 1
 
@@ -24,8 +25,9 @@ Adding a New Tileset and Displaying in OpenLayers
 =================================================
 
 MapCache is configured using XML files. OSGeoLive includes an example configuration file at ``/home/user/mapcache/mapcache-quickstart.xml``. 
-The example uses the OSGeoLive demo MapServer application of Itasca County in the United States as its source. In this quick start we will 
-set up tile caching for an additional WMS layer and display the tiles in a simple HTML page containing an OpenLayers map. 
+The example uses the OSGeoLive demo MapServer application of Itasca County in the United States as its source. 
+
+In this quick start we will set up tile caching for an additional WMS layer and display the tiles in a simple HTML page containing an OpenLayers map. 
 
 First let's open the MapCache configuration file in LeafPad - a text editor. Navigate to ``/home/user/mapcache`` in the File Manager, 
 right-click on ``mapcache-quickstart.xml`` and select LeafPad. 


### PR DESCRIPTION
Reviewed as part of the QuickStart project during Google Season of Docs 2019. The aim is consistency across all OSGeoLive QuickStarts.
The document is structured well and only requires very minor changes.
@geographika Please action comments and suggestions you agree with, and ignore those you don't.

Partner trac ticket link:
https://trac.osgeo.org/osgeolive/ticket/2196

See this page for reference: https://trac.osgeo.org/osgeolive/wiki/How%20to%20document%20the%20quickstart%20file