### PR TITLE
Reviewed opencpn QuickStart

### DIFF
--- a/doc/quickstart/opencpn_quickstart.rst
+++ b/doc/quickstart/opencpn_quickstart.rst
@@ -57,7 +57,7 @@ option.
 .. no longer true? : (for this reason we have not started gpsd automatically)
 
 
-* '`xgps`' is a good program to check that Gpsd can see your GPS ok.
+.. Note:: '`xgps`' is a good program to check that Gpsd can see your GPS ok.
 
 
 Things to try

--- a/doc/quickstart/opencpn_quickstart.rst
+++ b/doc/quickstart/opencpn_quickstart.rst
@@ -30,12 +30,9 @@ This is a condition of redistributing NOAA's free nautical charts. The first tim
 #. Click :guilabel:`I agree` to the NOAA Nautical Chart Data Agreement.
 #. Click :guilabel:`OK` to agree to the OpenCPN license.
 
-.. To do this manually, open a Terminal from the main Accessories menu and
- run :command:`opencpn_noaa_agreement.sh` at the command prompt. The user's
- password is given in the file on the main desktop.
+.. To do this manually, open a Terminal from the main Accessories menu and run :command:`opencpn_noaa_agreement.sh` at the command prompt. The user's password is given in the file on the main desktop.
 
-You can download additional US nautical charts from NOAA
-at http://www.charts.noaa.gov
+You can download additional US nautical charts from NOAA at http://www.charts.noaa.gov
 
 
 Setting up your GPS
@@ -75,6 +72,7 @@ Current weather and wave forecast data can be downloaded and draped over your ch
 
 
 Run through the :doc:`zyGrib quickstart <../quickstart/zygrib_quickstart>` and load the zyGrib file over your chart.
+
 .. Note::
   If you saved the zyGrib file into your home directory, navigate to :file:`/home` and select your ``user`` directory as the GRIB data directory. Then right click on the file listing's background to show hidden files, including the ``.zygrib`` directory that contains the GRIB download files.
 

--- a/doc/quickstart/opencpn_quickstart.rst
+++ b/doc/quickstart/opencpn_quickstart.rst
@@ -57,7 +57,7 @@ option.
 .. no longer true? : (for this reason we have not started gpsd automatically)
 
 
-.. Note:: '`xgps`' is a good program to check that Gpsd can see your GPS ok.
+.. Tip:: '`xgps`' is a good program to check that Gpsd can see your GPS ok.
 
 
 Things to try
@@ -73,8 +73,7 @@ Current weather and wave forecast data can be downloaded and draped over your ch
 
 Run through the :doc:`zyGrib quickstart <../quickstart/zygrib_quickstart>` and load the zyGrib file over your chart.
 
-.. Note::
-  If you saved the zyGrib file into your home directory, navigate to :file:`/home` and select your ``user`` directory as the GRIB data directory. Then right click on the file listing's background to show hidden files, including the ``.zygrib`` directory that contains the GRIB download files.
+.. Note:: If you saved the zyGrib file into your home directory, navigate to :file:`/home` and select your ``user`` directory as the GRIB data directory. Then right click on the file listing's background to show hidden files, including the ``.zygrib`` directory that contains the GRIB download files.
 
   There is no need to uncompress the file.  Click on the ">" to the left of the filename and select from the list of available forecast times.
 

--- a/doc/quickstart/opencpn_quickstart.rst
+++ b/doc/quickstart/opencpn_quickstart.rst
@@ -1,5 +1,6 @@
 :Author: Hamish Bowman
-:Version: osgeolive6.5
+:Reviewer: Felicity Brand (Google Season of Docs 2019)
+:Version: osgeolive13.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 :Copyright: 2011 by The OSGeo Foundation
 
@@ -7,25 +8,27 @@
 @OSGEO_KIND_opencpn@
 
 
-********************************************************************************
+*************************
 @NAME_opencpn@ Quickstart
-********************************************************************************
+*************************
 
 OpenCPN is a concise Chart Plotter and Navigator (CPN). As always, never
 use a piece of software or electronic equipment as your only means of
 navigation and keep an eye out the window.
 
+.. contents:: Contents
+   :local:
 
-Running
-================================================================================
 
 Setting up your charts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+======================
+
 Before running OpenCPN on the LiveDVD you should activate the sample data.
-This is a condition of redistributing NOAA's free nautical charts.
-The first time you run OpenCPN from
-the :menuselection:`Geospatial --> Navigation and Maps` menu or Desktop icon
-you will be presented with the option to do this automatically.
+This is a condition of redistributing NOAA's free nautical charts. The first time you open OpenCPN you are presented with the option to do this automatically.
+
+#. From the Start menu, select :menuselection:`Geospatial --> Navigation and Maps --> OpenCPN`.
+#. Click :guilabel:`I agree` to the NOAA Nautical Chart Data Agreement.
+#. Click :guilabel:`OK` to agree to the OpenCPN license.
 
 .. To do this manually, open a Terminal from the main Accessories menu and
  run :command:`opencpn_noaa_agreement.sh` at the command prompt. The user's
@@ -36,9 +39,10 @@ at http://www.charts.noaa.gov
 
 
 Setting up your GPS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+===================
+
 If you have a GPS connected you will want to start the gpsd service.
-To do that run:
+To do that, open a terminal and run:
 
 ::
 
@@ -59,30 +63,31 @@ option.
 * '`xgps`' is a good program to check that Gpsd can see your GPS ok.
 
 
-Documentation
-================================================================================
+Things to try
+=============
 
-* Documentation is available from
-  the `Help menu <../../opencpn/help_en_US.html>`_, or
-  online at http://www.opencpn.org/ocpn/opencpn_manual
+Current weather and wave forecast data can be downloaded and draped over your charts using the GRIB plugin. The :doc:`zyGrib software <../overview/zygrib_overview>` (also on this disc) is an easy way to download that. 
+
+#. Click the :guilabel:`Options` icon on the toolbar. The Options window displays.
+#. Select the :guilabel:`Plugins` tab.
+#. Choose GRIB and then click :guilabel:`Enable`.
+#. Click :guilabel:`OK`. A windsock icon is now displayed on the toolbar.
+
+
+Run through the :doc:`zyGrib quickstart <../quickstart/zygrib_quickstart>` and load the zyGrib file over your chart.
+.. Note::
+  If you saved the zyGrib file into your home directory, navigate to :file:`/home` and select your ``user`` directory as the GRIB data directory. Then right click on the file listing's background to show hidden files, including the ``.zygrib`` directory that contains the GRIB download files.
+
+  There is no need to uncompress the file.  Click on the ">" to the left of the filename and select from the list of available forecast times.
+
+
+What next?
+==========
+
+* Documentation is available from the Help menu or online at https://opencpn.org/OpenCPN/info/manuals.html
 
 *  `Getting started tips <../../opencpn/tips.html>`_
 
+* Website: http://www.opencpn.org
 
-See also
-================================================================================
-
-Current weather and wave forecast data can be downloaded and draped over your
-charts using the GRIB plugin. The :doc:`zyGrib software <../overview/zygrib_overview>`
-(also on this disc) is an easy way to download that. See
-the :doc:`zyGrib quickstart <../quickstart/zygrib_quickstart>` for details.
-Enable the plugin from the right most tab of the OpenCPN configuration menu;
-a new windsock icon will appear at the right end of the main toolbar.
-
-If you saved the zyGrib file into your home directory, navigate
-to :file:`/home` and select your ``user`` directory as the GRIB data directory.
-Then right click on the file listing's background to show hidden files, including
-the ``.zygrib`` directory that contains the GRIB download files.
-
-There is no need to uncompress the file.  Click on the ">" to the left of
-the filename and select from the list of available forecast times.
+* Support: http://www.cruisersforum.com/forums/f134


### PR DESCRIPTION
Reviewed as part of the QuickStart project during Google Season of Docs 2019. The aim is consistency across all OSGeoLive QuickStarts.

The document required some changes to headings and structure. I added numbers to procedures.
@HamishB  Please action comments and suggestions you agree with, and ignore those you don't.

Partner trac ticket link: https://trac.osgeo.org/osgeolive/ticket/2204

See this page for reference: https://trac.osgeo.org/osgeolive/wiki/How%20to%20document%20the%20quickstart%20file
