### PR TITLE
Add Windows CI Builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,55 @@
+image: Visual Studio 2017
+
+cache:
+  - '%LOCALAPPDATA%\\pip\\Cache'
+
+environment:
+  VS_VERSION: Visual Studio 15 2017
+  matrix:
+  - platform: x64
+    PYTHON: "C:\\Python37-x64"
+
+    
+
+matrix:
+  fast_finish: true
+
+shallow_clone: true
+
+# https://www.appveyor.com/docs/windows-images-software/#perl
+# Perl 5.20.1.2000 x86 (C:\Perl in PATH)
+
+build_script:
+
+  - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  # strawberry-perl-5.26.2.1-64bit-portable
+  - "SET PERL_HOME=C:\\Perl"
+  - "SET PATH=%PERL_HOME%\\perl\\site\\bin;%PERL_HOME%\\perl\\bin;%PERL_HOME%\\c\\bin;%PATH%"
+  
+  - "python -m pip install --upgrade pip"
+  - pip install sphinx==1.6.5
+  - pip install sphinx-intl
+  - pip install sphinxjp.themes.revealjs
+  
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - mkdir build
+  - cd build
+  - cmake -DHTML=ON ..
+  - cmake --build . --config Release
+  # - msbuild ALL_BUILD.vcxproj
+  
+deploy: off
+
+after_test:
+  - cd %BUILD_FOLDER%
+  - 7z a osgeolive-doc.zip ./build/doc/_build/html/* > nul
+
+# Uncomment to enable debugging on the server
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))  
+
+artifacts:
+  - path: osgeolive-doc.zip
+    name: osgeolive-doc
+    type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2017
 
 cache:
-  - '%LOCALAPPDATA%\\pip\\Cache'
+  - '%LOCALAPPDATA%\pip\Cache'
   - C:\strawberry
 
 environment:
@@ -15,8 +15,6 @@ matrix:
 
 shallow_clone: true
 
-
-
 install:
   - if not exist "C:\strawberry" choco install strawberryperl -y
 
@@ -25,7 +23,7 @@ build_script:
   - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
-  # using strawberry-perl
+  # using strawberryperl
   - set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
   - cpanm Text::SimpleTable::AutoWidth
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   
   - "python -m pip install --upgrade pip"
-  - pip install requirements.txt
+  - pip install -r requirements.txt
 
   - mkdir build
   - cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,12 +33,11 @@ build_script:
   #- cpan App::cpanminus
   #- cpanm Text::SimpleTable::AutoWidth
 
-  - "python -m pip install --upgrade pip"
-  - pip install sphinx==1.6.5
-  - pip install sphinx-intl
-  - pip install sphinxjp.themes.revealjs
-
   - cd %APPVEYOR_BUILD_FOLDER%
+  
+  - "python -m pip install --upgrade pip"
+  - pip install requirements.txt
+
   - mkdir build
   - cd build
   - cmake -DHTML=ON ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ environment:
   - platform: x64
     PYTHON: "C:\\Python37-x64"
 
-    
-
 matrix:
   fast_finish: true
 
@@ -23,6 +21,7 @@ build_script:
 
   - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
   # strawberry-perl-5.26.2.1-64bit-portable
   - "SET PERL_HOME=C:\\Perl"
   - "SET PATH=%PERL_HOME%\\perl\\site\\bin;%PERL_HOME%\\perl\\bin;%PERL_HOME%\\c\\bin;%PATH%"
@@ -31,14 +30,16 @@ build_script:
   - pip install sphinx==1.6.5
   - pip install sphinx-intl
   - pip install sphinxjp.themes.revealjs
-  
+
+  - cpan App::cpanminus
+  - cpanm Text::SimpleTable::AutoWidth
+
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build
   - cmake -DHTML=ON ..
   - cmake --build . --config Release
-  # - msbuild ALL_BUILD.vcxproj
-  
+
 deploy: off
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ image: Visual Studio 2017
 
 cache:
   - '%LOCALAPPDATA%\\pip\\Cache'
+  - C:\strawberry
 
 environment:
   VS_VERSION: Visual Studio 15 2017
@@ -14,25 +15,30 @@ matrix:
 
 shallow_clone: true
 
-# https://www.appveyor.com/docs/windows-images-software/#perl
-# Perl 5.20.1.2000 x86 (C:\Perl in PATH)
+
+
+install:
+  - if not exist "C:\strawberry" choco install strawberryperl -y
 
 build_script:
 
   - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
-  # strawberry-perl-5.26.2.1-64bit-portable
-  - "SET PERL_HOME=C:\\Perl"
-  - "SET PATH=%PERL_HOME%\\perl\\site\\bin;%PERL_HOME%\\perl\\bin;%PERL_HOME%\\c\\bin;%PATH%"
-  
+  # using strawberry-perl
+  - set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
+  - cpanm Text::SimpleTable::AutoWidth
+
+  # using Appveyor preinstalled Perl - https://www.appveyor.com/docs/windows-images-software/#perl
+  #- "SET PERL_HOME=C:\\Perl"
+  #- "SET PATH=%PERL_HOME%\\perl\\site\\bin;%PERL_HOME%\\perl\\bin;%PERL_HOME%\\c\\bin;%PATH%"
+  #- cpan App::cpanminus
+  #- cpanm Text::SimpleTable::AutoWidth
+
   - "python -m pip install --upgrade pip"
   - pip install sphinx==1.6.5
   - pip install sphinx-intl
   - pip install sphinxjp.themes.revealjs
-
-  - cpan App::cpanminus
-  - cpanm Text::SimpleTable::AutoWidth
 
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
@@ -43,12 +49,12 @@ build_script:
 deploy: off
 
 after_test:
-  - cd %BUILD_FOLDER%
+  - cd %APPVEYOR_BUILD_FOLDER%
   - 7z a osgeolive-doc.zip ./build/doc/_build/html/* > nul
 
 # Uncomment to enable debugging on the server
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))  
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))  
 
 artifacts:
   - path: osgeolive-doc.zip


### PR DESCRIPTION
This pull request builds the OSGeoLive docs on a Windows machine. This can serve two purposes:

1. Provide a working example of how to build the OSGeoLive docs locally on a Windows machine (with Python and Perl installs and CMake). 
2. Upload the output as an "Artifacts " that can be downloaded for a visual review on any open (non-merged) pull request. Artifacts older than 6 months are automatically deleted. 

In order to setup Appveyor the OSGeoLive-doc project needs to be added as a project to the OSGeo Appveyor account. Anyone with GitHub access to OSGeo should be able to do this (maybe @rouault as GDAL has Appveyor builds? Or I can configure ifgranted access). 
