### PR TITLE
Reviewed GeoServer Quickstart

### DIFF
--- a/doc/quickstart/geoserver_quickstart.rst
+++ b/doc/quickstart/geoserver_quickstart.rst
@@ -207,18 +207,11 @@ Adding the Style to |GS|
 Now we need to transfer these styles to |GS|.
 #. On the style window there is an export button which allows me to save the SLD file that
 defines my style. 
-#. Once I've saved the two styles I can go to the |GS|
-admin page again and select ``Styles`` (at the bottom of the ``Data``
-section). 
-#. Select the ``Add New Style`` link. At the bottom of
-that page is a file upload box and a browse button. 
-#. Clicking browse to find the files you just
-saved. 
-#. Click the upload link (next to the browse
-button) and a copy of the file appears in the editor. 
-#. If you click on the
-validate button the highlighted lines will give you an error but you can
-safely ignore the error (or delete those lines as they don't do anything).
+#. Once I've saved the two styles I can go to the |GS| admin page again and select ``Styles`` (at the bottom of the ``Data`` section). 
+#. Select the ``Add New Style`` link. At the bottom of that page is a file upload box and a browse button. 
+#. Clicking browse to find the files you just saved. 
+#. Click the upload link (next to the browse button) and a copy of the file appears in the editor. 
+#. If you click on the validate button the highlighted lines will give you an error but you can safely ignore the error (or delete those lines as they don't do anything).
 #. Press the :guilabel:`Submit` at the bottom of the page.
 
 .. image:: /images/projects/geoserver/geoserver-add-style.png
@@ -230,13 +223,11 @@ safely ignore the error (or delete those lines as they don't do anything).
 Adding the Style to the Layer
 --------------------------------------------------------------------------------
 
-#. Click on the :guilabel:`Layers` link in the Menu on the left of the
-|GS| window. 
-#. Click on the layer (e.g. *ne_10m_land*), then select the 
-:guilabel:`Publishing` tab.
-#. Change the :guilabel:`Default Style`
-box to the name of the style you uploaded in the previous section.
+#. Click on the :guilabel:`Layers` link in the Menu on the left of the |GS| window. 
+#. Click on the layer (e.g. *ne_10m_land*), then select the :guilabel:`Publishing` tab.
+#. Change the :guilabel:`Default Style` box to the name of the style you uploaded in the previous section.
 #. Now click :guilabel:`Save` and go to the Layer Preview page to check that it looks good.
+
 
 .. note:: There are example style files for all of the example Natural Earth layers in :file:`/usr/local/share/geoserver`. 
 

--- a/doc/quickstart/geoserver_quickstart.rst
+++ b/doc/quickstart/geoserver_quickstart.rst
@@ -34,7 +34,7 @@ This Quick Start describes how to:
 Start Geoserver
 ===============
 
-#. From the Start menu, select :menuselection:`Geospatial --> Web Services --> GeoServer --> Start GeoServer`. The application will take a few moments to start up and will open a web page at http://localhost:8082/geoserver/web 
+#. From the Start menu, select |osgeolive-appmenupath-geoserver|. The application will take a few moments to start up and will open a web page at http://localhost:8082/geoserver/web 
 
    .. image:: /images/projects/geoserver/geoserver-login.png
     :scale: 70 %
@@ -231,6 +231,14 @@ Adding the style to the layer
     raster. If you go to the Layers Preview page you
     can see the new image. 
 
+Clients for WMS layers
+================================================================================
+
+The `WMS <http://www.opengeospatial.org/standards/wms>`__ layers you are serving from |GS| can be used with a variety of clients on this OSGeoLive distribution, including: 
+
+* :doc:`uDig <../overview/udig_overview>`
+* :doc:`OpenLayers <../overview/openlayers_overview>`
+* :doc:`MapBender <../overview/mapbender_overview>`
 
 Add a layer from a NetCDF file
 ===============================

--- a/doc/quickstart/geoserver_quickstart.rst
+++ b/doc/quickstart/geoserver_quickstart.rst
@@ -18,7 +18,7 @@
 @NAME_geoserver@ Quickstart
 ********************************************************************************
 
-GeoServer is a java application for serving maps (and data) for other clients to draw.
+GeoServer is a java application for serving maps (and data) for other clients (such as web browsers) to draw. GeoServer comes with a browser-based management interface and connects to multiple data sources at the back end.
 
 This Quick Start describes how to:
 

--- a/doc/quickstart/geoserver_quickstart.rst
+++ b/doc/quickstart/geoserver_quickstart.rst
@@ -206,14 +206,15 @@ Adding the Style to |GS|
 
 Now we need to transfer these styles to |GS|.
 
-#. On the style window there is an export button which allows me to save the SLD file that
+1. On the style window there is an export button which allows me to save the SLD file that
 defines my style. 
-#. Once I've saved the two styles I can go to the |GS| admin page again and select ``Styles`` (at the bottom of the ``Data`` section). 
-#. Select the ``Add New Style`` link. At the bottom of that page is a file upload box and a browse button. 
-#. Clicking browse to find the files you just saved. 
-#. Click the upload link (next to the browse button) and a copy of the file appears in the editor. 
-#. If you click on the validate button the highlighted lines will give you an error but you can safely ignore the error (or delete those lines as they don't do anything).
-#. Press the :guilabel:`Submit` at the bottom of the page.
+2. Once I've saved the two styles I can go to the |GS| admin page again and select ``Styles`` (at the bottom of the ``Data`` section). 
+3. Select the ``Add New Style`` link. At the bottom of that page is a file upload box and a browse button. 
+4. Clicking browse to find the files you just saved. 
+5. Click the upload link (next to the browse button) and a copy of the file appears in the editor. 
+6. If you click on the validate button the highlighted lines will give you an error but you can safely ignore the error (or delete those lines as they don't do anything).
+7. Press the :guilabel:`Submit` at the bottom of the page.
+
 
 .. image:: /images/projects/geoserver/geoserver-add-style.png
    :align: center

--- a/doc/quickstart/geoserver_quickstart.rst
+++ b/doc/quickstart/geoserver_quickstart.rst
@@ -3,7 +3,7 @@
 :Reviewer: Angelos Tzotsos
 :Reviewer: Cameron Shorter
 :Reviewer: Felicity Brand (Google Season of Docs 2019)
-:Version: osgeolive11.0
+:Version: osgeolive12.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 :Thanks: geoserver-user list
 
@@ -18,8 +18,7 @@
 @NAME_geoserver@ Quickstart
 ********************************************************************************
 
-GeoServer is a java application for serving maps (and data) for other
-clients to draw.
+GeoServer is a java application for serving maps (and data) for other clients to draw.
 
 This Quick Start describes how to:
 
@@ -30,31 +29,32 @@ This Quick Start describes how to:
   * add a layer from a NetCDF file
 
 .. contents:: Contents
+   :local:
   
-Start @NAME_geoserver@
-================================================================================
+Start Geoserver
+===============
 
-1. Select the |osgeolive-appmenupath-geoserver| in the menu. The application will take a few moments to start up and will open a web page at http://localhost:8082/geoserver/web 
+#. From the Start menu, select :menuselection:`Geospatial --> Web Services --> GeoServer --> Start GeoServer`. The application will take a few moments to start up and will open a web page at http://localhost:8082/geoserver/web 
 
-.. image:: /images/projects/geoserver/geoserver-login.png
+   .. image:: /images/projects/geoserver/geoserver-login.png
     :scale: 70 %
 
-2. Log in using the username **admin** and password **geoserver**. You will now see the *admin page*.
+#. Log in using the username **admin** and password **geoserver**. You will now see the *admin page*.
 
-.. image:: /images/projects/geoserver/geoserver-welcome.png
+   .. image:: /images/projects/geoserver/geoserver-welcome.png
     :scale: 70 %
 
-3. Select the **Layer Preview** link at the top of the *Data* section in the left hand menu to see a preview of the layers that are loaded on the server. 
+#. Select the **Layer Preview** link at the top of the *Data* section in the left hand menu to see a preview of the layers that are loaded on the server. 
   
-.. image:: /images/projects/geoserver/geoserver-layerpreview.png
+   .. image:: /images/projects/geoserver/geoserver-layerpreview.png
     :scale: 70 %
 
-4. Scroll to the bottom of the page and click on the **OpenLayers** link in the **tiger-ny** row. This will open a new window with a preview of some of the sample data. 
+#. Scroll to the bottom of the page and click on the **OpenLayers** link in the **tiger-ny** row. This will open a new window with a preview of some of the sample data. 
 
-.. image:: /images/projects/geoserver/geoserver-preview.png
+   .. image:: /images/projects/geoserver/geoserver-preview.png
     :scale: 70 %
     
-5. You can zoom in to the map in three ways:
+#. You can zoom in to the map in three ways:
 
         * by clicking on the zoom bar on the left, the higher you click on it the more zoomed in you will see.
 
@@ -64,8 +64,8 @@ Start @NAME_geoserver@
 
 Experiment with this view and look at some of the other previews.  Once you are comfortable viewing existing data you can move on to adding some new data.
 
-Loading Data
-================================================================================
+Loading data
+============
 
 .. HB comment: is the following still true? 6.5rc2 worked for me from a DVD+R
 
@@ -78,143 +78,120 @@ Loading Data
 In this example we are going to use the :doc:`Natural Earth data set <../overview/naturalearth_overview>`
 that is included on OSGeoLive (:file:`/usr/local/share/data/natural_earth2/`).
 
-1. We need to create a Store for our data. From the |GS| admin page go
-to :guilabel:`Stores`.
-2. Click on :guilabel:`Add new Store`. You
-will see this page:
+#. We need to create a Store for our data. From the |GS| admin page go to :guilabel:`Stores`.
+#. Click on :guilabel:`Add new Store`. You will see this page:
 
-.. image:: /images/projects/geoserver/geoserver-newstore.png
-    :scale: 70 %
-    :align: center
-    :alt: The New Store page
+   .. image:: /images/projects/geoserver/geoserver-newstore.png
+      :scale: 70 %
+      :align: center
+      :alt: The New Store page
 
-3. Select the :guilabel:`Directory of spatial files`. You will see the following: 
+#. Select the :guilabel:`Directory of spatial files`. You will see the following: 
 
-.. image:: /images/projects/geoserver/geoserver-new-vector.png
-    :scale: 70 %
-    :align: center
-    :alt: Filling in the New Store page
+   .. image:: /images/projects/geoserver/geoserver-new-vector.png
+      :scale: 70 %
+      :align: center
+      :alt: Filling in the New Store page
 
-4. Type in a name for the Data Store (for example, *Natural Earth*) and fill in
-the URL to the data set - in this case :file:`/usr/local/share/data/natural_earth2/`. 
-You can use the browse button to find the directory if your data is somewhere else. 
-5. Press :guilabel:`save`.
+#. Type in a name for the Data Store (for example, *Natural Earth*) and fill in the URL to the data set - in this case :file:`/usr/local/share/data/natural_earth2/`. You can use the browse button to find the directory if your data is somewhere else. 
+#. Press :guilabel:`save`.
 
-.. image:: /images/projects/geoserver/geoserver-naturalearth.png
-    :align: center 
-    :scale: 70 %
-    :alt: The Natural Earth Datastore
+   .. image:: /images/projects/geoserver/geoserver-naturalearth.png
+      :align: center 
+      :scale: 70 %
+      :alt: The Natural Earth Datastore
 
-6. Press :guilabel:`publish` next to one of the layers to finish adding the data. This will take you to the *Layers* page:
+#. Press :guilabel:`publish` next to one of the layers to finish adding the data. This will take you to the *Layers* page:
 
-.. image:: /images/projects/geoserver/geoserver-publish.png
-    :align: center
-    :scale: 70 %
-    :alt: The layer publishing page
+   .. image:: /images/projects/geoserver/geoserver-publish.png
+      :align: center
+      :scale: 70 %
+      :alt: The layer publishing page
 
-As you scroll down the page you will see that |GS| has filled in many of
-the fields for you. When you reach :guilabel:`Coordinate Reference System`
-you will notice that under *Native SRS* it says UNKNOWN 
-you will need to fill in the next box (*declared SRS*) to make sure |GS|
-knows where the data is. 
+   As you scroll down the page you will see that |GS| has filled in many of the fields for you. When you reach :guilabel:`Coordinate Reference System` you will notice that under *Native SRS* it says UNKNOWN you will need to fill in the next box (*declared SRS*) to make sure |GS| knows where the data is. 
 
-7. You can type epsg:4326 in the box, or go to `http://prj2epsg.org/search <http://prj2epsg.org/search>`_ and paste in the string you see if you click on the link next to "UNKNOWN".
-8. Click on :guilabel:`Compute from data` and :guilabel:`Compute from native bounds` to fill in the Bounding Boxes. 
-9. Finally hit :guilabel:`save` and you have published your first layer.
+#. You can type epsg:4326 in the box, or go to `http://prj2epsg.org/search <http://prj2epsg.org/search>`_ and paste in the string you see if you click on the link next to "UNKNOWN".
+#. Click on :guilabel:`Compute from data` and :guilabel:`Compute from native bounds` to fill in the Bounding Boxes. 
+#. Finally hit :guilabel:`save` and you have published your first layer.
 
 .. note::
-    Don't worry if the layer preview doesn't look
-    very good as it is using the default style. In the next section
-    we will look at producing a nicer style.
+    Don't worry if the layer preview doesn't look very good as it is using the default style. In the next section we will look at producing a nicer style.
 
 You can follow the same step with the other layers in the directory by using the :guilabel:`Add a new resource` button on the layers page. Just select the natural earth store from the drop down box to get back to the store's page.
 
-Styling Data
-================================================================================
+Styling data
+============
 
-Styling a data set into a map layer |GS| uses an OGC standard called
-`Styled Layer Descriptors (SLD) <http://www.opengeospatial.org/standards/sld>`__. These 
-are represented as XML files which describe the rules that are used to 
-apply various symbolizers to the data.
+Styling a data set into a map layer |GS| uses an OGC standard called `Styled Layer Descriptors (SLD) <http://www.opengeospatial.org/standards/sld>`__. These are represented as XML files which describe the rules that are used to apply various symbolizers to the data.
 
 To get started, lets style the Land and Ocean datasets. 
-You can create SLD files using a simple text editor, but
-sometimes a graphical editor is better. There are several options here
-but |UG| allows you to open the shapefiles directly 
-and apply simple styles using a GUI. It also provides a simple editor 
-to modify the XML if I need to. 
+You can create SLD files using a simple text editor, but sometimes a graphical editor is better. There are several options here but |UG| allows you to open the shapefiles directly and apply simple styles using a GUI. It also provides a simple editor to modify the XML if I need to. 
 
-Using |UG| to Create Simple Styles
---------------------------------------------------------------------------------
+Using |UG| to create simple styles
+----------------------------------
 
 .. note::
 
    For more details on how to use |UG| see the :doc:`uDig Quickstart <../quickstart/udig_quickstart>`
 
-1. Open |UG| and add the shapefiles (using the add data button in the top left hand corner). 
-2. Drag the ne_10m_land and ne_10m_ocean tables into the map window. |UG| automatically applies
-a style (so you can see the data).
+#. Open |UG| and add the shapefiles (using the add data button in the top left hand corner). 
+#. Drag the ne_10m_land and ne_10m_ocean tables into the map window. |UG| automatically applies a style (so you can see the data).
 
-.. image:: /images/projects/geoserver/geoserver-udig_startup.png
-   :align: center
-   :scale: 70 %
-   :alt: Default Styling in uDig
+   .. image:: /images/projects/geoserver/geoserver-udig_startup.png
+     :align: center
+     :scale: 70 %
+     :alt: Default Styling in uDig
 
-3. In the :ref:`Layer list <Layer_list>` select the style button (it looks like an artist's palette). 
+#. In the :ref:`Layer list <Layer_list>` select the style button (it looks like an artist's palette). 
 
-.. _Layer_list:
-.. image:: /images/projects/geoserver/geoserver-layer-chooser.png
-   :align: center
-   :scale: 70 %
-   :alt: The Layer list window
+   .. _Layer_list:
+   .. image:: /images/projects/geoserver/geoserver-layer-chooser.png
+     :align: center
+     :scale: 70 %
+     :alt: The Layer list window
 
-This will open the :ref:`Style Pane <Style_Pane>`. 
-4. In the simple window we can easily select a nice blue for the oceans by clicking on the colored box on the fill tab and choosing from the color picker it produces. We can also
-increase the opacity of the fill to 100% to make the color look
-better. Pick the same blue for the border color so it will match.
+   This will open the :ref:`Style Pane <Style_Pane>`. 
+#. In the simple window we can easily select a nice blue for the oceans by clicking on the colored box on the fill tab and choosing from the color picker it produces. We can also increase the opacity of the fill to 100% to make the color look better. Pick the same blue for the border color so it will match.
 
-.. _Style_Pane:
-.. image:: /images/projects/geoserver/geoserver-style-pane.png
-   :align: center
-   :scale: 70 %
-   :alt: The Style Pane 
+   .. _Style_Pane:
+   .. image:: /images/projects/geoserver/geoserver-style-pane.png
+     :align: center
+     :scale: 70 %
+     :alt: The Style Pane 
 
-5. Click ``OK`` and |UG| will display the changes. 
+#. Click ``OK`` and |UG| will display the changes. 
 
+   .. image:: /images/projects/geoserver/geoserver-blue-ocean.png
+     :align: center
+     :scale: 70 %
+     :alt: Blue Oceans
 
-.. image:: /images/projects/geoserver/geoserver-blue-ocean.png
-   :align: center
-   :scale: 70 %
-   :alt: Blue Oceans
+#. Repeat the steps above to change the color of the land layer. You can use the ``define custom colors`` section to create your preferred color.
 
-6. Repeat the steps above to change the color of the land layer. You can use the ``define custom colors`` section to create your preferred color.
+   .. image:: /images/projects/geoserver/geoserver-custom-colour.png
+     :align: center
+     :scale: 70 %
+     :alt: Defining a nicer land color
 
-.. image:: /images/projects/geoserver/geoserver-custom-colour.png
-   :align: center
-   :scale: 70 %
-   :alt: Defining a nicer land color
-
-This gives me a nice looking basic world map
+This gives a nice looking basic world map.
 
 .. image:: /images/projects/geoserver/geoserver-basic-world.png
    :align: center
    :scale: 70 %
    :alt: A basic word map
 
-Adding the Style to |GS|
---------------------------------------------------------------------------------
+Adding the style to GeoServer
+-----------------------------
 
 Now we need to transfer these styles to |GS|.
 
-1. On the style window there is an export button which allows me to save the SLD file that
-defines my style. 
-2. Once I've saved the two styles I can go to the |GS| admin page again and select ``Styles`` (at the bottom of the ``Data`` section). 
-3. Select the ``Add New Style`` link. At the bottom of that page is a file upload box and a browse button. 
-4. Clicking browse to find the files you just saved. 
-5. Click the upload link (next to the browse button) and a copy of the file appears in the editor. 
-6. If you click on the validate button the highlighted lines will give you an error but you can safely ignore the error (or delete those lines as they don't do anything).
-7. Press the :guilabel:`Submit` at the bottom of the page.
-
+#. On the style window there is an export button which allows you to save the SLD file that defines your style. 
+#. Once saved, you can go to the |GS| admin page again and select ``Styles`` (at the bottom of the ``Data`` section). 
+#. Select the ``Add New Style`` link. At the bottom of that page is a file upload box and a browse button. 
+#. Clicking browse to find the files you just saved. 
+#. Click the upload link (next to the browse button) and a copy of the file appears in the editor. 
+#. If you click on the validate button the highlighted lines will give you an error but you can safely ignore the error (or delete those lines as they don't do anything).
+#. Press the :guilabel:`Submit` at the bottom of the page.
 
 .. image:: /images/projects/geoserver/geoserver-add-style.png
    :align: center
@@ -222,8 +199,8 @@ defines my style.
    :alt: Adding a Style to GeoServer
 
 
-Adding the Style to the Layer
---------------------------------------------------------------------------------
+Adding the style to the layer
+-----------------------------
 
 #. Click on the :guilabel:`Layers` link in the Menu on the left of the |GS| window. 
 #. Click on the layer (e.g. *ne_10m_land*), then select the :guilabel:`Publishing` tab.
@@ -255,22 +232,22 @@ Adding the Style to the Layer
     can see the new image. 
 
 
-Add a Layer from a NetCDF File
-================================================================================
+Add a layer from a NetCDF file
+===============================
 
 The GeoServer NetCDF plugin allows the publication of rasters from NetCDF files.
 
-Configure a NetCDF Store
---------------------------------------------------------------------------------
+Configure a NetCDF store
+------------------------
 
 #. After running "Start GeoServer"
-#. Login as the administrator'
-#. Click on "Add stores" then "NetCDF". 
+#. Login as the administrator.
+#. Click on :guilabel:`Add stores` then :guilabel:`NetCDF`. 
 #. Enter a value for Data Source Name (this example uses "netcdf") and a NetCDF URL. You can use this sample file::
 
     file:///usr/local/share/data/netcdf/polyphemus_20120401.nc
 
-#. Press "Save", "Publish" the "O3" layer, 
+#. Press "Save", "Publish" the "O3" layer.
 #. Scroll down to the bottom of the "Data" tab and press "Save" again.
 
     .. image:: /images/projects/geoserver/geoserver-netcdf-store.png
@@ -278,8 +255,8 @@ Configure a NetCDF Store
         :scale: 100 %
         :alt: Adding a NetCDF store
 
-Preview the NetCDF Layer
---------------------------------------------------------------------------------
+Preview the NetCDF layer
+------------------------
 
 #. Select "Layer Preview" from the menu on the left
 #. Scroll down to find the "cite:O3" entry, and click on the "OpenLayers" link to show a preview of the layer. 
@@ -293,24 +270,15 @@ Preview the NetCDF Layer
 .. note::
     This GeoServer instance has been configured with the ``NETCDF_DATA_DIR`` Java system property to allow the publication of NetCDF files in read-only directories.
 
-What Next?
-================================================================================
+What next?
+==========
 
-This is only the first step on the road to using GeoServer. There is
-a lot more functionality you can try.
+This is only the first step on the road to using GeoServer. There is a lot more functionality you can try.
 
-GeoServer Project home
+* GeoServer Project home - http://geoserver.org/
 
-  http://geoserver.org/
+* GeoServer User Manual - http://docs.geoserver.org/latest/en/user/
 
-GeoServer User Manual
+* GeoServer Tutorials - http://docs.geoserver.org/latest/en/user/tutorials/index.html
 
-  http://docs.geoserver.org/latest/en/user/
-
-GeoServer Tutorials
-
-  http://docs.geoserver.org/latest/en/user/tutorials/index.html
-
-GeoServer Styling Workshop
-
-  http://docs.geoserver.org/latest/en/user/styling/workshop/index.html
+* GeoServer Styling Workshop - http://docs.geoserver.org/latest/en/user/styling/workshop/index.html

--- a/doc/quickstart/geoserver_quickstart.rst
+++ b/doc/quickstart/geoserver_quickstart.rst
@@ -2,6 +2,7 @@
 :Author: Frank Gasdorf
 :Reviewer: Angelos Tzotsos
 :Reviewer: Cameron Shorter
+:Reviewer: Felicity Brand (Google Season of Docs 2019)
 :Version: osgeolive11.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 :Thanks: geoserver-user list
@@ -30,34 +31,30 @@ This Quick Start describes how to:
 
 .. contents:: Contents
   
-Start |GS|
+Start @NAME_geoserver@
 ================================================================================
 
-#. Select the |osgeolive-appmenupath-geoserver| in the menu.
-#. The application will take a few moments to start up and will open a web page at http://localhost:8082/geoserver/web 
+1. Select the |osgeolive-appmenupath-geoserver| in the menu. The application will take a few moments to start up and will open a web page at http://localhost:8082/geoserver/web 
 
 .. image:: /images/projects/geoserver/geoserver-login.png
     :scale: 70 %
 
-First Views
-================================================================================
-
-When you first open the |GS| page you will see the screen above, first you need to log in using the username **admin** and password **geoserver**. You will now see the *admin page*.
+2. Log in using the username **admin** and password **geoserver**. You will now see the *admin page*.
 
 .. image:: /images/projects/geoserver/geoserver-welcome.png
     :scale: 70 %
 
-Select the **Layer Preview** link at the top of the *Data* section in the left hand menu to see a preview of the layers that are loaded on the server. 
+3. Select the **Layer Preview** link at the top of the *Data* section in the left hand menu to see a preview of the layers that are loaded on the server. 
   
 .. image:: /images/projects/geoserver/geoserver-layerpreview.png
     :scale: 70 %
 
-Scroll to the bottom of the page and click on the **OpenLayers** link in the **tiger-ny** row, this will open a new window with a preview of some of the sample data. 
+4. Scroll to the bottom of the page and click on the **OpenLayers** link in the **tiger-ny** row. This will open a new window with a preview of some of the sample data. 
 
 .. image:: /images/projects/geoserver/geoserver-preview.png
     :scale: 70 %
     
-You can zoom in to the map in three ways:
+5. You can zoom in to the map in three ways:
 
         * by clicking on the zoom bar on the left, the higher you click on it the more zoomed in you will see.
 
@@ -81,8 +78,9 @@ Loading Data
 In this example we are going to use the :doc:`Natural Earth data set <../overview/naturalearth_overview>`
 that is included on OSGeoLive (:file:`/usr/local/share/data/natural_earth2/`).
 
-We need to create a Store for our data. From the |GS| admin page go
-to :guilabel:`Stores` and then click on :guilabel:`Add new Store`. You
+1. We need to create a Store for our data. From the |GS| admin page go
+to :guilabel:`Stores`.
+2. Click on :guilabel:`Add new Store`. You
 will see this page:
 
 .. image:: /images/projects/geoserver/geoserver-newstore.png
@@ -90,24 +88,24 @@ will see this page:
     :align: center
     :alt: The New Store page
 
-Select the :guilabel:`Directory of spatial files`, you will see the following: 
+3. Select the :guilabel:`Directory of spatial files`. You will see the following: 
 
 .. image:: /images/projects/geoserver/geoserver-new-vector.png
     :scale: 70 %
     :align: center
     :alt: Filling in the New Store page
 
-Type in a name for the Data Store - I used *Natural Earth* and fill in
+4. Type in a name for the Data Store (for example, *Natural Earth*) and fill in
 the URL to the data set - in this case :file:`/usr/local/share/data/natural_earth2/`. 
-You can use the browse button to find the directory if your data is somewhere else. Press :guilabel:`save`.
+You can use the browse button to find the directory if your data is somewhere else. 
+5. Press :guilabel:`save`.
 
 .. image:: /images/projects/geoserver/geoserver-naturalearth.png
     :align: center 
     :scale: 70 %
     :alt: The Natural Earth Datastore
 
-Press :guilabel:`publish` next to one of the layers to finish up adding
-the data. This will take you to the *Layers* page:
+6. Press :guilabel:`publish` next to one of the layers to finish adding the data. This will take you to the *Layers* page:
 
 .. image:: /images/projects/geoserver/geoserver-publish.png
     :align: center
@@ -116,14 +114,13 @@ the data. This will take you to the *Layers* page:
 
 As you scroll down the page you will see that |GS| has filled in many of
 the fields for you. When you reach :guilabel:`Coordinate Reference System`
-you will notice that under *Native SRS* that it says UNKNOWN 
+you will notice that under *Native SRS* it says UNKNOWN 
 you will need to fill in the next box (*declared SRS*) to make sure |GS|
-knows where the data is. For the time being trust me and type epsg:4326 in
-the box, if you don't trust me then go to `http://prj2epsg.org/search <http://prj2epsg.org/search>`_ and
-paste in the string you see if you click on the link next to "UNKNOWN".
-Then click on :guilabel:`Compute from data` and :guilabel:`Compute from
-native bounds` to fill in the Bounding Boxes. Finally hit :guilabel:`save`
-and you have published your first layer.
+knows where the data is. 
+
+7. You can type epsg:4326 in the box, or go to `http://prj2epsg.org/search <http://prj2epsg.org/search>`_ and paste in the string you see if you click on the link next to "UNKNOWN".
+8. Click on :guilabel:`Compute from data` and :guilabel:`Compute from native bounds` to fill in the Bounding Boxes. 
+9. Finally hit :guilabel:`save` and you have published your first layer.
 
 .. note::
     Don't worry if the layer preview doesn't look
@@ -132,31 +129,30 @@ and you have published your first layer.
 
 You can follow the same step with the other layers in the directory by using the :guilabel:`Add a new resource` button on the layers page. Just select the natural earth store from the drop down box to get back to the store's page.
 
-Styling
---------------------------------------------------------------------------------
+Styling Data
+================================================================================
 
-To style a data set into a map layer |GS| uses an OGC standard called
+Styling a data set into a map layer |GS| uses an OGC standard called
 `Styled Layer Descriptors (SLD) <http://www.opengeospatial.org/standards/sld>`__. These 
 are represented as XML files which describe the rules that are used to 
 apply various symbolizers to the data.
 
-To get started I styled the Land and Ocean datasets. 
+To get started, lets style the Land and Ocean datasets. 
 You can create SLD files using a simple text editor, but
 sometimes a graphical editor is better. There are several options here
-but I like to use |UG| as it allows me to open the shapefiles directly 
-and apply simple styles using a GUI, but also provides a simple editor 
+but |UG| allows you to open the shapefiles directly 
+and apply simple styles using a GUI. It also provides a simple editor 
 to modify the XML if I need to. 
 
-Using |UG| to create simple styles
-``````````````````````````````````
+Using |UG| to Create Simple Styles
+--------------------------------------------------------------------------------
 
 .. note::
 
    For more details on how to use |UG| see the :doc:`uDig Quickstart <../quickstart/udig_quickstart>`
 
-Once I opened |UG| up and added the shapefiles (using the
-add data button in the top left hand corner). I dragged the ne_10m_land
-and ne_10m_ocean tables into the map window. |UG| automatically applies
+1. Open |UG| and add the shapefiles (using the add data button in the top left hand corner). 
+2. Drag the ne_10m_land and ne_10m_ocean tables into the map window. |UG| automatically applies
 a style (so you can see the data).
 
 .. image:: /images/projects/geoserver/geoserver-udig_startup.png
@@ -164,9 +160,7 @@ a style (so you can see the data).
    :scale: 70 %
    :alt: Default Styling in uDig
 
-Now obviously an orange ocean will not work (even if I could live
-with the green land). So in the :ref:`Layer list <Layer_list>` select the style
-button (it looks like an artist's palette). 
+3. In the :ref:`Layer list <Layer_list>` select the style button (it looks like an artist's palette). 
 
 .. _Layer_list:
 .. image:: /images/projects/geoserver/geoserver-layer-chooser.png
@@ -174,11 +168,10 @@ button (it looks like an artist's palette).
    :scale: 70 %
    :alt: The Layer list window
 
-This will open the :ref:`Style Pane <Style_Pane>` - in the simple window I can easily
-select a nice blue for the oceans by clicking on the colored box on
-the fill tab and choosing from the color picker it produces. I also
-increased the opacity of the fill to 100% to make the color look
-better. I picked the same blue for the border color so it would match.
+This will open the :ref:`Style Pane <Style_Pane>`. 
+4. In the simple window we can easily select a nice blue for the oceans by clicking on the colored box on the fill tab and choosing from the color picker it produces. We can also
+increase the opacity of the fill to 100% to make the color look
+better. Pick the same blue for the border color so it will match.
 
 .. _Style_Pane:
 .. image:: /images/projects/geoserver/geoserver-style-pane.png
@@ -186,8 +179,7 @@ better. I picked the same blue for the border color so it would match.
    :scale: 70 %
    :alt: The Style Pane 
 
-Once I was done I clicked ``OK`` and |UG| showed me the
-changes. 
+5. Click ``OK`` and |UG| will display the changes. 
 
 
 .. image:: /images/projects/geoserver/geoserver-blue-ocean.png
@@ -195,10 +187,7 @@ changes.
    :scale: 70 %
    :alt: Blue Oceans
 
-Finally I prefer a more understated land color than green so
-I repeated the steps above to change the color of the land layer.
-None of the default colors seemed right to me so I went into the
-``define custom colors`` section to create one I liked.
+6. Repeat the steps above to change the color of the land layer. You can use the ``define custom colors`` section to create your preferred color.
 
 .. image:: /images/projects/geoserver/geoserver-custom-colour.png
    :align: center
@@ -213,20 +202,24 @@ This gives me a nice looking basic world map
    :alt: A basic word map
 
 Adding the Style to |GS|
-````````````````````````
+--------------------------------------------------------------------------------
 
-Now we need to transfer these styles to |GS| - on the style window
-there is an export button which allows me to save the SLD file that
-defines my style. Once I've saved the two styles I can go to the |GS|
+Now we need to transfer these styles to |GS|.
+#. On the style window there is an export button which allows me to save the SLD file that
+defines my style. 
+#. Once I've saved the two styles I can go to the |GS|
 admin page again and select ``Styles`` (at the bottom of the ``Data``
-section). Then I select the ``Add New Style`` link, at the bottom of
-that page is a file upload box and a browse button. Clicking this
-allows me to hunt around on my hard drive to find the files I just
-saved. Once I've found one I want, I click the upload link (next to the browse
-button) and a copy of my file appears in the editor. If you click on the
+section). 
+#. Select the ``Add New Style`` link. At the bottom of
+that page is a file upload box and a browse button. 
+#. Clicking browse to find the files you just
+saved. 
+#. Click the upload link (next to the browse
+button) and a copy of the file appears in the editor. 
+#. If you click on the
 validate button the highlighted lines will give you an error but you can
 safely ignore the error (or delete those lines as they don't do anything).
-When you are ready press the :guilabel:`Submit` at the bottom of the page.
+#. Press the :guilabel:`Submit` at the bottom of the page.
 
 .. image:: /images/projects/geoserver/geoserver-add-style.png
    :align: center
@@ -237,11 +230,13 @@ When you are ready press the :guilabel:`Submit` at the bottom of the page.
 Adding the Style to the Layer
 --------------------------------------------------------------------------------
 
-Click on the :guilabel:`Layers` link in the Menu on the left of the
-|GS| window. Click on the layer (e.g. *ne_10m_land*), then select the 
-:guilabel:`Publishing` tab and change the :guilabel:`Default Style`
+#. Click on the :guilabel:`Layers` link in the Menu on the left of the
+|GS| window. 
+#. Click on the layer (e.g. *ne_10m_land*), then select the 
+:guilabel:`Publishing` tab.
+#. Change the :guilabel:`Default Style`
 box to the name of the style you uploaded in the previous section.
-Now click :guilabel:`Save` and go to the Layer Preview page to check that it looks good.
+#. Now click :guilabel:`Save` and go to the Layer Preview page to check that it looks good.
 
 .. note:: There are example style files for all of the example Natural Earth layers in :file:`/usr/local/share/geoserver`. 
 
@@ -267,41 +262,35 @@ Now click :guilabel:`Save` and go to the Layer Preview page to check that it loo
     can see the new image. 
 
 
-Clients for WMS layers
-================================================================================
-
-A large variety of clients exist to make use of the `WMS <http://www.opengeospatial.org/standards/wms>`__ layers you are serving
-from |GS|. This is a list of just some of them 
-
-    * :doc:`uDig <../overview/udig_overview>`
-
-    * :doc:`OpenLayers <../overview/openlayers_overview>`
-
-    * :doc:`MapBender <../overview/mapbender_overview>`
-
-NetCDF
+Add a Layer from a NetCDF File
 ================================================================================
 
 The GeoServer NetCDF plugin allows the publication of rasters from NetCDF files.
 
-Configure a NetCDF store
-------------------------
+Configure a NetCDF Store
+--------------------------------------------------------------------------------
 
-After running "Start GeoServer", login as the administrator, click on "Add stores" then "NetCDF". Enter a value for Data Source Name (this example uses "netcdf") and a NetCDF URL. You can use this sample file::
+#. After running "Start GeoServer"
+#. Login as the administrator'
+#. Click on "Add stores" then "NetCDF". 
+#. Enter a value for Data Source Name (this example uses "netcdf") and a NetCDF URL. You can use this sample file::
 
     file:///usr/local/share/data/netcdf/polyphemus_20120401.nc
 
-Press "Save", "Publish" the "O3" layer, then scroll down to the bottom of the "Data" tab and press "Save" again.
+#. Press "Save", "Publish" the "O3" layer, 
+#. Scroll down to the bottom of the "Data" tab and press "Save" again.
 
     .. image:: /images/projects/geoserver/geoserver-netcdf-store.png
         :align: center
         :scale: 100 %
         :alt: Adding a NetCDF store
 
-Preview the NetCDF layer
-------------------------
+Preview the NetCDF Layer
+--------------------------------------------------------------------------------
 
-Select "Layer Preview" from the menu on the left, scroll down to find the "cite:O3" entry, and click on the "OpenLayers" link to show a preview of the layer. Clicking on points will cause the value of "Ozone_concentration" to be shown in a table at the bottom of the map.
+#. Select "Layer Preview" from the menu on the left
+#. Scroll down to find the "cite:O3" entry, and click on the "OpenLayers" link to show a preview of the layer. 
+#. Clicking on points will cause the value of "Ozone_concentration" to be shown in a table at the bottom of the map.
 
     .. image:: /images/projects/geoserver/geoserver-netcdf-preview.png
         :align: center

--- a/doc/quickstart/geoserver_quickstart.rst
+++ b/doc/quickstart/geoserver_quickstart.rst
@@ -3,7 +3,7 @@
 :Reviewer: Angelos Tzotsos
 :Reviewer: Cameron Shorter
 :Reviewer: Felicity Brand (Google Season of Docs 2019)
-:Version: osgeolive12.0
+:Version: osgeolive11.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 :Thanks: geoserver-user list
 

--- a/doc/quickstart/geoserver_quickstart.rst
+++ b/doc/quickstart/geoserver_quickstart.rst
@@ -205,6 +205,7 @@ Adding the Style to |GS|
 --------------------------------------------------------------------------------
 
 Now we need to transfer these styles to |GS|.
+
 #. On the style window there is an export button which allows me to save the SLD file that
 defines my style. 
 #. Once I've saved the two styles I can go to the |GS| admin page again and select ``Styles`` (at the bottom of the ``Data`` section). 


### PR DESCRIPTION
Reviewed as part of the QuickStart project during Google Season of Docs 2019. The aim is consistency across all OSGeoLive QuickStarts.
I added numbered steps and changed heading style and wording. Also modified the What Next? section. @fgdrf Please action comments and suggestions you agree with, and ignore those you don't.

Partner trac ticket link: https://trac.osgeo.org/osgeolive/ticket/2210

See this page for reference: https://trac.osgeo.org/osgeolive/wiki/How%20to%20document%20the%20quickstart%20file
