### PR TITLE
Reviewed marble quickstart

### DIFF
--- a/doc/quickstart/marble_quickstart.rst
+++ b/doc/quickstart/marble_quickstart.rst
@@ -1,5 +1,6 @@
 :Author: Sergey Popov
 :Reviewer: Angelos Tzotsos, OSGeo
+:Reviewer: Felicity Brand (Google Season of Docs 2019)
 :Version: osgeolive11.0
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 :Copyright: 2015 by The OSGeo Foundation
@@ -11,21 +12,27 @@
 @NAME_marble@ Quickstart
 ********************************************************************************
 
+Marble is an open source KDE Education Project program similar to NASA World Wind or Google Earth. Besides choosing any number of maps to view on your globe (including OpenStreetMaps), you are encouraged to include a KDE Marble widget in your application.
+
 .. contents:: Contents
+   :local:
+   
+Start Marble
+============
 
-Getting Started
-================================================================================
-
-* Click on the desktop icon in the "Navigation and Maps" folder to open Marble. You will see a window like this:
+On the desktop, choose :menuselection:`Navigation and Maps --> Marble`. You will see a window like this:
 
      .. image:: /images/projects/marble/marble-quickstart-1.png
        :scale: 70 %
 
-You can:
 
-  #. Scale the globe by rotating the wheel of your mouse. To move around press the left button of your mouse and move it.
+Change the display
+==================
 
-  #. Marble has got 11 different views: 
+* Scale the globe by rotating the wheel of your mouse. 
+* To move around press the left button of your mouse and move it.
+
+Marble has 11 different views (themes): 
 
     - Atlas
     - OpenStreetMap
@@ -39,44 +46,53 @@ You can:
     - Temperature (December)
     - Temperature (July).
 
-  #. To switch them click one of entries in "Theme" list in "Map View" tab.
+* Click one of entries in the "Theme" list in "Map View" tab to switch between them.
 
   .. image:: /images/projects/marble/marble-quickstart-2.png
     :scale: 70 %
 
-  #. Press a label in any place to view more information about it.
+* Click a label in any place to view more information about it.
 
   .. image:: /images/projects/marble/marble-quickstart-3.png
     :scale: 70 %
 
-  #. Close panels by clicking the cross at the top-right corner of the panel. To close all the panels press "F9" or go to "Settings->Panels->Hide All Panels". Also you can show/hide a panel by clicking its title at the "Settings->Panels" menu.
+	
+Find a location
+===============	
 
-  .. image:: /images/projects/marble/marble-quickstart-4.png
-    :scale: 70 %
-
-  #. To find a location, enter its name into the search line on the top of "Search" panel. As you start typing, suggestions below the search line will appear like this:
+To find a location, enter its name into the search line on the top of "Search" panel. 
+As you start typing, suggestions below the search line will appear like this:
 
   .. image:: /images/projects/marble/marble-quickstart-5.png
     :scale: 70 %
+	
+	
+Add a bookmark
+==============
 
-  #. Use bookmarks in Marble to remember the location of something. To add a bookmark press the left button of your mouse and click "Add bookmark". After it a window will appear like this:
+Use bookmarks in Marble to remember the location of something. 
 
-  .. image:: /images/projects/marble/marble-quickstart-6.png
-    :scale: 70 %
+#. To add a bookmark, press the left button of your mouse and click "Add bookmark". A window will appear like this:
 
-  #. Write the name, description and destination folder of the bookmark and click the "Ok" button. Then the bookmark will appear. To manage bookmarks, go to "Bookmarks->Manage Bookmarks". 
+   .. image:: /images/projects/marble/marble-quickstart-6.png
+     :scale: 70 %
+
+#. Write the name, description and destination folder of the bookmark
+#. Click the "Ok" button. Then the bookmark will appear. 
+
+To manage bookmarks, go to "Bookmarks->Manage Bookmarks". 
 
   .. image:: /images/projects/marble/marble-quickstart-7.png
     :scale: 70 %
 
-Things to Try
-================================================================================
+Things to try
+=============
 
-See the `Marble documentation <https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ and try to use the Routing feature.
+Try to use the Routing feature. See the `Marble documentation <https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ for help.
 
 
-What Next?
-================================================================================
+What next?
+==========
 
-See the `Marble homepage <https://marble.kde.org/>`_ for more help.
+See the `Marble homepage <https://marble.kde.org/>`_ for more information.
 


### PR DESCRIPTION
Reviewed as part of the Quicktart project during Google Season of Docs 2019. The aim is consistency across all OSGeoLive Quickstarts.
The document is structured well and only requires minor changes. I added some headings and numbered steps. @Sergobot Please action comments and suggestions you agree with, and ignore those you don't.

Partner trac ticket link: https://trac.osgeo.org/osgeolive/ticket/2226

See this page for reference: https://trac.osgeo.org/osgeolive/wiki/How%20to%20document%20the%20quickstart%20file
