### PR TITLE
Fix RST warnings and errors

### DIFF
--- a/doc/quickstart/52nWPS_quickstart.rst
+++ b/doc/quickstart/52nWPS_quickstart.rst
@@ -45,34 +45,34 @@ Process data
 
 1. Click on the link to open the 52nWPS-TestClient. 
 
-  .. image:: /images/projects/52nWPS/52nWPS_welcome_page_2.png
-    :scale: 70 %
-    :alt: screenshot
+   .. image:: /images/projects/52nWPS/52nWPS_welcome_page_2.png
+     :scale: 70 %
+     :alt: screenshot
 
 2. Make sure that :doc:`GeoServer <../overview/geoserver_overview>` is running since the demonstration requires data from the local GeoServer installation.
 3. To do this, try to open the page http://localhost:8082/geoserver/web. If the page could not be found, select |osgeolive-appmenupath-geoserver| in the menu. The GeoServer should be running after a few moments.
 
 4. Select the example request "SimpleBuffer_out_wfs.xml" from the dropdown list:
   
-  .. image:: /images/projects/52nWPS/52nWPS_test_client.png
-    :scale: 70 %
-    :alt: screenshot
+   .. image:: /images/projects/52nWPS/52nWPS_test_client.png
+     :scale: 70 %
+     :alt: screenshot
   
 5. Push the Send-Button and the request will be transmitted to the 52°North WPS which will
-  generate a buffer around the major roads of Tasmania with a width of 0.05 degrees and store
-  the result in GeoServer. 
+   generate a buffer around the major roads of Tasmania with a width of 0.05 degrees and store
+   the result in GeoServer. 
 
-  .. image:: /images/projects/52nWPS/52nWPS_output_stored_in_wfs.png
-    :scale: 70 %
-    :alt: screenshot
+   .. image:: /images/projects/52nWPS/52nWPS_output_stored_in_wfs.png
+     :scale: 70 %
+     :alt: screenshot
   
 6. Copy the ResourceID from the response. This is the name of the GeoServer layer. Add the ID to the
-  following request: http://localhost:8082/geoserver/wms?service=WMS&version=1.1.0&request=GetMap&styles=&bbox=145.14757902405984,-43.47330297262748,148.32274986232298,-40.80286290459129&width=512&height=430&srs=EPSG:4326&format=application/openlayers&layers=Add-ResourceID-here
-  You should get the following result:
+   following request: http://localhost:8082/geoserver/wms?service=WMS&version=1.1.0&request=GetMap&styles=&bbox=145.14757902405984,-43.47330297262748,148.32274986232298,-40.80286290459129&width=512&height=430&srs=EPSG:4326&format=application/openlayers&layers=Add-ResourceID-here
+   You should get the following result:
 
-  .. image:: /images/projects/52nWPS/52nWPS_result_in_geoserver.png
-    :scale: 70 %
-    :alt: screenshot
+   .. image:: /images/projects/52nWPS/52nWPS_result_in_geoserver.png
+     :scale: 70 %
+     :alt: screenshot
 
 Things to try
 =============

--- a/doc/quickstart/R_quickstart.rst
+++ b/doc/quickstart/R_quickstart.rst
@@ -32,7 +32,7 @@ press return, and the R interpreter evaluates it and prints the
 result.
 
 .. Tip:: Don't fear the command line - it is a source of great power. Using the up and down arrows
-to recall commands so you can edit mistakes. Hit CTRL-C if get stuck and you should get the prompt back.
+   to recall commands so you can edit mistakes. Hit CTRL-C if get stuck and you should get the prompt back.
 
 Choose :menuselection:`Geospatial --> Spatial Tools --> R Statistics`. A terminal window opens running R.
 

--- a/doc/quickstart/eoxserver_quickstart.rst
+++ b/doc/quickstart/eoxserver_quickstart.rst
@@ -136,13 +136,10 @@ This is a simple demonstration, but you can do much more with EOxServer. The
 project website contains a lot of resources to help you get started. Here’s 
 a few resources to check out next:
 
-* See the :doc:`EOxServer Overview <../overview/eoxserver_overview>`_ for more information.
-* Read the `EOxServer Operators' Guide 
-  <https://eoxserver.readthedocs.org/en/latest/users/operators.html>`_.
-* Read the complete `EOxServer Users' documentation 
-  <https://eoxserver.readthedocs.org/en/latest/users/index.html>`_ starting from
-  the `EOxServer Basics
-  <https://eoxserver.readthedocs.org/en/latest/users/basics.html>`_.
+* See the :doc:`EOxServer Overview <../overview/eoxserver_overview>` for more information.
+* Read the `EOxServer Operators' Guide <https://eoxserver.readthedocs.org/en/latest/users/operators.html>`_.
+* Read the complete `EOxServer Users' documentation <https://eoxserver.readthedocs.org/en/latest/users/index.html>`_
+  starting from the `EOxServer Basics <https://eoxserver.readthedocs.org/en/latest/users/basics.html>`_.
 * If you are already in the OSGeoLive environment, read the local copy of the `EOxServer Users' local documentation
   <https://localhost/eoxserver-docs/EOxServer_documentation.pdf>`_
 * Ready to use EOxServer? Then join the community on the `mailing lists 

--- a/doc/quickstart/geomajas_quickstart.rst
+++ b/doc/quickstart/geomajas_quickstart.rst
@@ -32,11 +32,10 @@ From the Desktop, select :menuselection:`Browser Clients --> Start Geomajas`. Wa
 Alternatively, you can then access the application using the following URL: `<http://localhost:8080/geomajas/>`_. 
 
 .. image:: /images/projects/geomajas/geomajas_screenshot.png
-    :width: 100%
-    :alt: The default view of the provided Geomajas application
+  :width: 100%
+  :alt: The default view of the provided Geomajas application
 
-  .. Tip:: When you’re finished using the application, select :menuselection:`Browser Clients --> Stop Geomajas`. 
-
+.. Tip:: When you’re finished using the application, select :menuselection:`Browser Clients --> Stop Geomajas`. 
 
 Navigating the map
 ==================

--- a/doc/quickstart/gvsig_quickstart.rst
+++ b/doc/quickstart/gvsig_quickstart.rst
@@ -59,7 +59,7 @@ Define the projection of your view
 
 #. Select :menuselection:`View --> Properties`.
 
-  .. image:: /images/projects/gvsig/gvsig_qs_002_.png
+   .. image:: /images/projects/gvsig/gvsig_qs_002_.png
      :scale: 55
 
 #. For the :guilabel:`Current projection`, click on the :guilabel:`...` button.
@@ -72,20 +72,19 @@ Define the projection of your view
 #. Select :guilabel:`OK` to return to the **View Properties** dialog. The EPSG code is now 4326 and that the map units have changed to degrees.
 #. Select :guilabel:`OK` to return to the **Project Manager**.
 
-  .. image:: /images/projects/gvsig/gvsig_qs_003_.png
-   :scale: 55
-
+.. image:: /images/projects/gvsig/gvsig_qs_003_.png
+  :scale: 55
 
 * (1) The view window consists of three zones.
 * (2) The top-left cell contains a list of vector or raster layers being used in
-   the view (i.e. Table-of-Contents).
+  the view (i.e. Table-of-Contents).
 * (3) The bottom-left cell displays the extent of the main view over a selected
-   vector file.
+  vector file.
 * (4) The right cell is the main display area where raster and vector data is
-   rendered.
+  rendered.
 
 .. image:: /images/projects/gvsig/gvsig_qs_005_.png
-   :scale: 55
+  :scale: 55
 
 Add layers to the view
 ======================

--- a/doc/quickstart/ideditor_quickstart.rst
+++ b/doc/quickstart/ideditor_quickstart.rst
@@ -207,7 +207,7 @@ Saving your changes
 ===================
 
 #. When (and if) you want to save your edits to OpenStreetMap, click the
-  **Save** button. The panel on the left will show the upload panel.
+   **Save** button. The panel on the left will show the upload panel.
 
    |image36|
 

--- a/doc/quickstart/josm_quickstart.rst
+++ b/doc/quickstart/josm_quickstart.rst
@@ -187,12 +187,13 @@ Draw your own map
 =================
 
 Now let’s draw a map in order to practice the techniques you have learned. You may wish to redraw the map that you drew on paper previously.
--  Drag the map away from the sample map. Hold the right mouse button
-   and drag your mouse, until you have a nice empty area to draw on.
--  Use the Draw tool to create points, lines, and shapes. Describe what
-   your objects are by selecting from the Presets menu.
--  When you are finished, you should have your own map, similar to the
-   sample map that we opened in sample.osm.
+
+- Drag the map away from the sample map. Hold the right mouse button
+  and drag your mouse, until you have a nice empty area to draw on.
+- Use the Draw tool to create points, lines, and shapes. Describe what
+  your objects are by selecting from the Presets menu.
+- When you are finished, you should have your own map, similar to the
+  sample map that we opened in sample.osm.
 
 Remove the sample layer
 =======================

--- a/doc/quickstart/ncWMS_quickstart.rst
+++ b/doc/quickstart/ncWMS_quickstart.rst
@@ -99,7 +99,8 @@ Vertical sections and transects along arbitrary paths
 #. Click on the map to start drawing a line. 
 #. Add "waypoints" along this line by single-clicking at each point. 
 #. Double-click to finish the line. 
-  A new browser window opens showing the variation of the viewed variable along the line (i.e. a transect plot). If the variable has a vertical dimension, a vertical section plot will display under the transect plot.
+   A new browser window opens showing the variation of the viewed variable along the line (i.e. a transect plot). If the variable has a vertical dimension, a vertical section plot will display under the transect plot.
+
 
 Changing the background map
 ---------------------------

--- a/doc/quickstart/openjump_quickstart.rst
+++ b/doc/quickstart/openjump_quickstart.rst
@@ -68,27 +68,27 @@ Edit feature geometries in a layer
 #. Click on the menu entry "Editable" so that a check mark is shown. This will open a new floating toolbar over the Map View on the right side. This toolbar has a set of buttons that you can use to edit the geometry of a geographic feature.
 
    .. image:: /images/projects/openjump/openjump_ss_05.png
-   :scale: 55 
-   
+     :scale: 55 
+
    .. image:: /images/projects/openjump/openjump_ss_06.png
-   :scale: 55 
+     :scale: 55 
 
 #. Let's try a quick edit. First we need to select a geometry and then we move a point of the geometry. To do that, we first click the button that shows a mouse cursor in the editing toolbar (top left button). 
 #. Activate it and click on a single feature in the Layer View to select it. If the selection worked, then the features line color should change to yellow and small yellow squares appear at each angle point (vertex) in the feature geometry. 
 
    .. image:: /images/projects/openjump/openjump_ss_07.png
-   :scale: 55 
+     :scale: 55 
 
 #. Next, click on the button that shows a blue crosshair with a yellow square in the middle, the :guilabel:`Move Vertex Tool` (Hoovering over the buttons gives you a button description). You should now see your mouse cursor change to a small black crosshair when you move it over the Map View. 
 
    .. image:: /images/projects/openjump/openjump_ss_08.png
-   :scale: 55 
+     :scale: 55 
 
 #. Try using this to move one of the vertices/points of the geometry you selected before by clicking on one of the vertices and dragging it (leaving the mouse button pressed).
 
    .. image:: /images/projects/openjump/openjump_ss_09.png
-   :scale: 55 
-   
+     :scale: 55 
+
 What next?
 ==========
 

--- a/doc/quickstart/pycsw_quickstart.rst
+++ b/doc/quickstart/pycsw_quickstart.rst
@@ -22,25 +22,25 @@ Run the tester application
 
 1. On the Desktop go to `Web Services --> pycsw` or open Firefox and navigate to ``http://localhost/pycsw/tests/index.html``:
 
-.. image:: /images/projects/pycsw/pycsw_tester_startup.png
-  :scale: 75 %
+   .. image:: /images/projects/pycsw/pycsw_tester_startup.png
+     :scale: 75 %
 
   By selecting the left drop-down list, the user can see various predefined POST requests, encoded as XML, that can be sent to pycsw. 
 
 2. Select "apiso/DescribeRecord" and press the "Send" button. A description of the ISO Application Profile record is presented on the right panel.
 
-.. image:: /images/projects/pycsw/pycsw_tester_describe_apiso_record.png
-  :scale: 75 %
+   .. image:: /images/projects/pycsw/pycsw_tester_describe_apiso_record.png
+     :scale: 75 %
 
 3. Selecting "GetCapabilities-SOAP" and press the "Send" button. A SOAP request is sent to the server to advertise their web service capabilities.
 
-.. image:: /images/projects/pycsw/pycsw_tester_soap_capabillities.png
-  :scale: 75 %
+   .. image:: /images/projects/pycsw/pycsw_tester_soap_capabillities.png
+     :scale: 75 %
 
 4. You can search for data records, performing a spatial bounding box query, by selecting "GetRecords-filter-bbox" and editing the coordinates in the XML request.
 
-.. image:: /images/projects/pycsw/pycsw_tester_getrecords_bbox_filter.png
-  :scale: 75 %
+   .. image:: /images/projects/pycsw/pycsw_tester_getrecords_bbox_filter.png
+     :scale: 75 %
 
 You can go through all the available requests and perform various requests from this testing application.
 

--- a/doc/quickstart/spatialite_quickstart.rst
+++ b/doc/quickstart/spatialite_quickstart.rst
@@ -79,9 +79,10 @@ Run an SQL query
 
 #. Now let's try tweaking this SQL statement to get NOME and (Lat,Long) for only the NOME_PROV fields include "BRESCIA", this time using the MunicipalHallsView.  In the upper right SQL pane type::
 
-   SELECT NOME, X(Geometry) AS Longitude, Y(Geometry) AS Latitude
+    SELECT NOME, X(Geometry) AS Longitude, Y(Geometry) AS Latitude
         FROM "MunicipalHallsView"
         WHERE NOME_PROV LIKE "BRESCIA";
+
 
 #. Click the "Execute SQL" button at the right, and see the results in the bottom right pane.
 
@@ -98,13 +99,15 @@ Users needing to script or automate queries will learn the advantages of working
 
 #. In the terminal open a sample database with **spatialite** by typing::
 
-   spatialite /home/user/data/spatialite/trento.sqlite
+    spatialite /home/user/data/spatialite/trento.sqlite
+
 
    Helpful commands from the command line::
+    
+     .help
+     .tables
+     .quit
 
-   .help
-   .tables
-   .quit   
 
 Create a new spatialite database and load a shapefile
 =====================================================


### PR DESCRIPTION
This pull request fixes the RST errors as seen in the latest [Travis build](https://api.travis-ci.com/v3/job/286799690/log.txt):

There remain 2 warnings in the Perl generated presentation.rst file

```

/home/user/OSGeoLive-doc/build/doc/quickstart/R_quickstart.rst:38: WARNING: Explicit markup ends without a blank line; unexpected unindent.

/home/user/OSGeoLive-doc/build/doc/quickstart/eoxserver_quickstart.rst:142: WARNING: Mismatch: both interpreted text role prefix and reference suffix.

/home/user/OSGeoLive-doc/build/doc/quickstart/geomajas_quickstart.rst:40: WARNING: Error in "image" directive:
no content permitted.

.. image:: /images/projects/geomajas/geomajas_screenshot.png
    :width: 100%
    :alt: The default view of the provided Geomajas application

  .. Tip:: When you’re finished using the application, select :menuselection:`Browser Clients --> Stop Geomajas`.
/home/user/OSGeoLive-doc/build/doc/quickstart/gvsig_quickstart.rst:87: WARNING: Enumerated list ends without a blank line; unexpected unindent.
/home/user/OSGeoLive-doc/build/doc/quickstart/gvsig_quickstart.rst:89: WARNING: Enumerated list ends without a blank line; unexpected unindent.
/home/user/OSGeoLive-doc/build/doc/quickstart/gvsig_quickstart.rst:91: WARNING: Enumerated list ends without a blank line; unexpected unindent.

/home/user/OSGeoLive-doc/build/doc/quickstart/ideditor_quickstart.rst:213: WARNING: Enumerated list ends without a blank line; unexpected unindent.
/home/user/OSGeoLive-doc/build/doc/quickstart/josm_quickstart.rst:194: WARNING: Unexpected indentation.
/home/user/OSGeoLive-doc/build/doc/quickstart/josm_quickstart.rst:195: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/user/OSGeoLive-doc/build/doc/quickstart/ncWMS_quickstart.rst:105: WARNING: Enumerated list ends without a blank line; unexpected unindent.

/home/user/OSGeoLive-doc/build/doc/quickstart/openjump_quickstart.rst:74: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/user/OSGeoLive-doc/build/doc/quickstart/openjump_quickstart.rst:77: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/user/OSGeoLive-doc/build/doc/quickstart/openjump_quickstart.rst:83: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/user/OSGeoLive-doc/build/doc/quickstart/openjump_quickstart.rst:88: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/user/OSGeoLive-doc/build/doc/quickstart/openjump_quickstart.rst:93: WARNING: Explicit markup ends without a blank line; unexpected unindent.

/home/user/OSGeoLive-doc/build/doc/quickstart/pycsw_quickstart.rst:31: WARNING: Error in "image" directive:
no content permitted.

.. image:: /images/projects/pycsw/pycsw_tester_startup.png
  :scale: 75 %

  By selecting the left drop-down list, the user can see various predefined POST requests, encoded as XML, that can be sent to pycsw.

/home/user/OSGeoLive-doc/build/doc/quickstart/spatialite_quickstart.rst:85: WARNING: Literal block expected; none found.
/home/user/OSGeoLive-doc/build/doc/quickstart/spatialite_quickstart.rst:104: WARNING: Literal block expected; none found.

```
