### PR TITLE
wip: Add python3 stemmer build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Johan Van de Wauw <johan.vandewauw@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), 
                python3-sphinx,
+               python3-stemmer
                python3-pil,
                pngquant,
                cmake,


### PR DESCRIPTION
Trying to solve https://launchpadlibrarian.net/500626823/buildlog_ubuntu-focal-amd64.osgeolive-docs_14.0~alpha1-0~202010041654~ubuntu20.04.1_BUILDING.txt.gz