### PR TITLE
virtualization_quickstart.rst updates

### DIFF
--- a/doc/quickstart/virtualization_quickstart.rst
+++ b/doc/quickstart/virtualization_quickstart.rst
@@ -14,9 +14,9 @@ This Quick Start describes one way to run OSGeoLive within a VirtualBox virtual 
 Virtual Machine Advantages
 --------------------------------------------------------------------------------
 
-* Response speed of a VM is much faster than on the DVD, and typically comparable with installing directly on the host machine.
+* The response speed of a VM is much faster than on the DVD, and typically comparable with installing directly on the host machine.
 
-* All configuration changes, software updates, and saved files are permanent, just like on any "regular" computer. So
+* All configuration changes, software updates, and saved files are permanent, just like on any "regular" computer. So:
 
  * You can customize and update the system
  * You can save your work within the VM
@@ -27,8 +27,9 @@ Virtual Machine Advantages
 System Requirements
 --------------------------------------------------------------------------------
 
-* RAM: 2 GB at least. The Lubuntu system runs well with 1 GB of RAM, and you'll need to keep at least the same amount of memory for your host system. So a total of 2 GB will be needed for smooth operation. Some applications, like geoserver, needs that the virtual machine has at least 2GB of RAM. So if possible, consider providing 2 GB or more for your virtual machine.
-* Spare Hard Disk Space: The virtual disk file (vmdk) from :doc:`live.osgeo.org <../download>`  unzips to almost 10 GB. And you'll want more space to allow some room to work on the virtual machine. So 20 GB is a good recommendation.
+* RAM: 2 GB at least. The Lubuntu system runs well with 1 GB of RAM, and you'll need to keep at least the same amount of memory for your host system.
+  So a total of 2 GB will be needed for smooth operation. Some applications, like GeoServer, needs the virtual machine to have at least 2GB of RAM. So if possible, consider providing 2 GB or more for your virtual machine.
+* Spare Hard Disk Space: The virtual disk file (vmdk) from :doc:`live.osgeo.org <../download>`  unzips to almost 10 GB. You'll also want more space to allow some room to work on the virtual machine. So 20 GB is a good recommendation.
 * CPU: Any CPU will do, but a processor which supports "Virtualization Technology" will be faster. You can check your computer CPU `here <https://www.intel.com/content/www/us/en/support/articles/000005486/processors.html>`__.
 
 Most machines produced in the last 4-5 years will meet these requirements.
@@ -38,7 +39,7 @@ Howto
 
 **Downloads**
 
-Download `Virtual Box <https://www.virtualbox.org/>`_  for your platform, and install the software. On windows run the installer, or on Ubuntu-like linux systems do the following:
+Download `Virtual Box <https://www.virtualbox.org/>`_  for your platform, and install the software. On Windows run the installer, or on Ubuntu-like Linux systems do the following:
 
   ``apt-get install virtualbox-ose``
 
@@ -58,17 +59,17 @@ Enter a name such as OSGeoLive, and choose Linux as the "Operating system", and 
   .. image:: /images/projects/osgeolive/virtualbox_select_name.png
          :scale: 70 %
 
-In the next screen set the memory to 1024 MB (or more if your host computer has more than 4GB, like on the screenshot).
+In the next screen set the memory to 1024 MB (or more if your host computer has more than 4GB, like in the screenshot below).
 
   .. image:: /images/projects/osgeolive/vmdk_memory.png
      :scale: 65 %
 
-Continue to the next screen and choose "Use existing hard disk" . Now click on the button (a folder icon) to browse to where you saved the OSGeoLive vmdk-file. Select this file, press Next and Create.
+Continue to the next screen and choose "Use an existing virtual hard disk file". Now click on the button (a folder icon) to browse to where you saved the OSGeoLive vmdk-file. Select this file, press Next and Create.
 
   .. image:: /images/projects/osgeolive/vmdk_disk.png
      :scale: 65 %
 
-** Config tips and tweaks**
+**Config tips and tweaks**
 
 Once the VM is created, click on the Settings button. In the "General" section, go to the Advanced tab, and click to select "Show at top of screen" for the Mini toolbar.
 
@@ -85,7 +86,7 @@ In addition, move to the "Shared Folders" section, and click the "Add folder" (g
   .. image:: /images/projects/osgeolive/vmdk_shared_folders.png
      :scale: 65 %
 
-You can select to make the shared folder read only, and auto-mounted. Once the "Folder path" and "Folder name" are defined, click OK, and again OK to finish and close the settings window.
+You can choose to make the shared folder read-only, and auto-mounted. Once the "Folder path" and "Folder name" are defined, click OK, and again OK to finish and close the settings window.
 
 
 **Running the Virtual Machine**
@@ -102,11 +103,11 @@ The solution is to fix the vmdk with the following one-time procedure:
 2.  Run "sudo adduser user users".
 3. Apply this change by starting a new desktop session: either restart the virtual machine or log out and log back in (username "user", password "user").
 
-Also once the OSGeo system comes up, add yourself to the vboxsf group so that the shared folders (defined above) are accessible by running in a terminal window:
+Also once the OSGeo system starts, add yourself to the vboxsf group so that the shared folders (defined above) are accessible by running in a terminal window:
 
 ``user@osgeolive:~$ sudo usermod -a -G vboxsf user``
 
-In the above example, we defined a Shared Folder path on the host system and named it "GIS" in the VM Settings. The shared folder will appear in the file system under /media/sf_GIS/. To mount this folder in the user's home directory, for example, in a terminal do:
+In the above example, we defined a Shared Folder path on the host system and named it "GIS" in the VM Settings. The shared folder will appear in the file system under /media/sf_GIS/. To mount this folder in the user's home directory, for example, in a terminal run:
 
 ``user@osgeolive:~$ mkdir GIS``
 


### PR DESCRIPTION
A few minor text changes and a RST bold fix following a read-through. 

Note this tutorial doesn't cover running an ISO directly in Virtual Box - is this covered elsewhere?
There is https://github.com/OSGeo/OSGeoLive-doc/blob/master/doc/quickstart/virtualbox_quickstart.rst - but this is not built as part of the docs, and has not been updated in several years. 

