### PR TITLE
Ignore twitter link due to 400 Client Error

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -283,6 +283,10 @@ linkcheck_ignore = [
         # Link with certiciate problems
         # Used in quickstart/liblas_quickstart
         'https://epsg.org/home.html',
+
+        # Link with error 400 Client Error
+        # Used in contact
+        r'https://mobile.twitter.com/osgeolive',
         ]
 
 linkcheck_anchors = False


### PR DESCRIPTION
Currently, check link action always fails due to `400 Client Error`.
https://github.com/OSGeo/OSGeoLive-doc/runs/1611601946?check_suite_focus=true#step:7:305
```
(line   38) broken    https://mobile.twitter.com/osgeolive - 400 Client Error: Bad Request for url: https://mobile.twitter.com/osgeolive
```

And I noticed that Twitter seems to limit accessible browser for the link.
```bash
$ curl -i https://mobile.twitter.com/osgeolive
HTTP/2 400 
:
<body>
  <div class="errorContainer">
    <img width="46" height="38"
      srcset="https://abs.twimg.com/errors/logo46x38.png 1x, https://abs.twimg.com/errors/logo46x38@2x.png 2x"
      src="https://abs.twimg.com/errors/logo46x38.png" alt="Twitter" />
    <h1>This browser is no longer supported.</h1>
    <p>
      Please switch to a supported browser to continue using twitter.com. You can see a list of supported browsers in our Help Center.
    </p>
    <p class="errorButton"><a href="https://help.twitter.com/using-twitter/twitter-supported-browsers">Help Center</a>
    </p>
    <p class="errorFooter">
      <a href="https://twitter.com/tos">Terms of Service</a>
      <a href="https://twitter.com/privacy">Privacy Policy</a>
      <a href="https://support.twitter.com/articles/20170514">Cookie Policy</a>
      <a href="https://legal.twitter.com/imprint">Imprint</a>
      <a href="https://business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html">Ads info</a>
      © 2020 Twitter, Inc.
    </p>
  </div>
</body>
```

So, I just added the twitter link to ignore targets.