### PR TITLE
Adjusted index quickstarts titles (only on rst files)

### DIFF
--- a/doc/quickstart/commandline_quickstart.rst
+++ b/doc/quickstart/commandline_quickstart.rst
@@ -4,7 +4,7 @@
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
 ********************************************************************************
-Command Line Quickstart
+Command Line basics
 ********************************************************************************
 
 When you work with GNU/Linux Operating Systems such as OSGeoLive, Ubuntu, etc., it is good to know how to work on the command line. 

--- a/doc/quickstart/hyperv_quickstart.rst
+++ b/doc/quickstart/hyperv_quickstart.rst
@@ -4,7 +4,7 @@
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
 ********************************************************************************
-OSGeoLive Quickstart for Running in a Hyper-V Virtual Machine
+Running in a Hyper-V Virtual Machine
 ********************************************************************************
 
 This Quick Start describes how to run OSGeoLive using Hyper-V, Microsoft's virtualisation software. For other methods, follow links from the "See Also" section below. 

--- a/doc/quickstart/internationalisation_quickstart.rst
+++ b/doc/quickstart/internationalisation_quickstart.rst
@@ -6,7 +6,7 @@
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
 ********************************************************************************
-OSGeoLive Internationalisation Quickstart
+Change language or keyboard type
 ********************************************************************************
 
 Switching Language

--- a/doc/quickstart/osgeolive_quickstart.rst
+++ b/doc/quickstart/osgeolive_quickstart.rst
@@ -5,7 +5,7 @@
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
 ********************************************************************************
-OSGeoLive Quickstart
+Getting started with OSGeoLive
 ********************************************************************************
 
 This Quick Start describes how to start OSGeoLive from a DVD or USB.

--- a/doc/quickstart/virtualization_quickstart.rst
+++ b/doc/quickstart/virtualization_quickstart.rst
@@ -6,7 +6,7 @@
 :License: Creative Commons Attribution-ShareAlike 3.0 Unported  (CC BY-SA 3.0)
 
 ********************************************************************************
-OSGeoLive Quickstart for Running in a Virtual Machine
+Running in a Virtual Machine
 ********************************************************************************
 
 This Quick Start describes one way to run OSGeoLive within a VirtualBox virtual machine. For other methods, follow links from the "See Also" section below.


### PR DESCRIPTION
This PR comes from the following discussion:
- https://trac.osgeo.org/osgeolive/ticket/2315#comment:3

I adjusted the titles **only on \*_quickstart.rst files**, so if these are no problem, propagating *.pot and each languages *.po files are quite helpful. (I don't know how to propagate those files...)
| No. | Original | Current | New | Comment |
|-----|---------|--------|------|-----------|
| 1 | Getting started with OSGeoLive | OSGeoLive Quickstart | Getting started with OSGeoLive | Revert back to original |
| 2 | Change language or keyboard type | OSGeoLive Internationalisation Quickstart  | Change language or keyboard type | Revert back to original |
| 3 | Install OSGeoLive on your hard disk | Install OSGeoLive to Hard Disk | Install OSGeoLive to Hard Disk | Keep current |
| 4 | Run OSGeoLive in a Virtual Machine | OSGeoLive Quickstart for Running in a Virtual Machine | Running in a Virtual Machine | Remove "OSGeoLive Quickstart for " from current |
| 5 | Create an OSGeoLive bootable USB thumb drive | Creating an OSGeoLive Bootable USB flash drive | Creating an OSGeoLive Bootable USB flash drive | Keep current |
| 6 | Running in a Hyper-V Virtual Machine | OSGeoLive Quickstart for Running in a Hyper-V Virtual Machine | OSGeoLive Quickstart for Running in a Hyper-V Virtual Machine | Remove "OSGeoLive Quickstart for " from current |
| 7 | Command Line basics | Command Line Quickstart | Command Line basics | Revert back to original |

Note that I am not native English speaker, so reviewing above `New` column changes is quite helpful.

Thanks,