### PR TITLE
Ol14 fix marble links

### DIFF
--- a/doc/quickstart/marble_quickstart.rst
+++ b/doc/quickstart/marble_quickstart.rst
@@ -91,7 +91,7 @@ To manage bookmarks, go to "Bookmarks->Manage Bookmarks".
 Things to try
 =============
 
-Try to use the Routing feature. See the `Marble documentation <https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ for help.
+Try to use the Routing feature. See the `Marble documentation <https://marble.kde.org>`_ for help.
 
 
 What next?

--- a/locale/de/LC_MESSAGES/quickstart/marble_quickstart.po
+++ b/locale/de/LC_MESSAGES/quickstart/marble_quickstart.po
@@ -182,10 +182,10 @@ msgstr "Was Sie noch ausprobieren können"
 #: ../../build/doc/quickstart/marble_quickstart.rst:100
 msgid ""
 "Try to use the Routing feature. See the `Marble documentation "
-"<https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ for help."
+"<https://marble.kde.org>`_ for help."
 msgstr ""
 "Versuchen Sie, die Routing-Funktion zu verwenden. Hilfe finden Sie in der "
-"<https: docs.kde.org/trunk5/en/kdeedu/marble/index.html=\"\">'Marble-"
+"<https: marble.kde.org=\"\">'Marble-"
 "Dokumentation'_.</https:>"
 
 #: ../../build/doc/quickstart/marble_quickstart.rst:104

--- a/locale/en/LC_MESSAGES/quickstart/marble_quickstart.po
+++ b/locale/en/LC_MESSAGES/quickstart/marble_quickstart.po
@@ -153,7 +153,7 @@ msgstr ""
 #: ../../build/doc/quickstart/marble_quickstart.rst:97
 msgid ""
 "Try to use the Routing feature. See the `Marble documentation "
-"<https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ for help."
+"<https://marble.kde.org>`_ for help."
 msgstr ""
 
 #: ../../build/doc/quickstart/marble_quickstart.rst:101

--- a/locale/es/LC_MESSAGES/quickstart/marble_quickstart.po
+++ b/locale/es/LC_MESSAGES/quickstart/marble_quickstart.po
@@ -175,10 +175,10 @@ msgstr "Cosas para probar"
 #: ../../build/doc/quickstart/marble_quickstart.rst:100
 msgid ""
 "Try to use the Routing feature. See the `Marble documentation "
-"<https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ for help."
+"<https://marble.kde.org>`_ for help."
 msgstr ""
 "Intente utilizar la Característica de Ruteo. Consulte la `Documentación de "
-"Marble <https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ para "
+"Marble <https://marble.kde.org>`_ para "
 "obtener ayuda."
 
 #: ../../build/doc/quickstart/marble_quickstart.rst:104

--- a/locale/fr/LC_MESSAGES/quickstart/marble_quickstart.po
+++ b/locale/fr/LC_MESSAGES/quickstart/marble_quickstart.po
@@ -178,10 +178,10 @@ msgstr "Choses à essayer"
 #: ../../build/doc/quickstart/marble_quickstart.rst:100
 msgid ""
 "Try to use the Routing feature. See the `Marble documentation "
-"<https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ for help."
+"<https://marble.kde.org>`_ for help."
 msgstr ""
 "Essayez d’utiliser la fonction Routage. Voir la documentation `documentation"
-" de Marble <https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ pour "
+" de Marble <https://marble.kde.org>`_ pour "
 "obtenir de l’aide."
 
 #: ../../build/doc/quickstart/marble_quickstart.rst:104

--- a/locale/hu/LC_MESSAGES/quickstart/marble_quickstart.po
+++ b/locale/hu/LC_MESSAGES/quickstart/marble_quickstart.po
@@ -173,10 +173,10 @@ msgstr "Kipróbálandó dolgok"
 #: ../../build/doc/quickstart/marble_quickstart.rst:100
 msgid ""
 "Try to use the Routing feature. See the `Marble documentation "
-"<https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ for help."
+"<https://marble.kde.org>`_ for help."
 msgstr ""
 "Próbálja ki az útvonalkeresés funkciót. További segítségért lásd a `Marble "
-"dokumentációt <https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_."
+"dokumentációt <https://marble.kde.org>`_."
 
 #: ../../build/doc/quickstart/marble_quickstart.rst:104
 msgid "What next?"

--- a/locale/ja/LC_MESSAGES/quickstart/marble_quickstart.po
+++ b/locale/ja/LC_MESSAGES/quickstart/marble_quickstart.po
@@ -163,10 +163,10 @@ msgstr "試してみること"
 #: ../../build/doc/quickstart/marble_quickstart.rst:100
 msgid ""
 "Try to use the Routing feature. See the `Marble documentation "
-"<https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ for help."
+"<https://marble.kde.org>`_ for help."
 msgstr ""
 "ルーティング機能を使用してみます。ヘルプについて、 `Marble ドキュメント "
-"<https://docs.kde.org/trunk5/en/kdeedu/marble/index.html>`_ を参照してください。"
+"<https://marble.kde.org>`_ を参照してください。"
 
 #: ../../build/doc/quickstart/marble_quickstart.rst:104
 msgid "What next?"


### PR DESCRIPTION
Change ​https://docs.kde.org/trunk5/en/kdeedu/marble/index.html" to "​https://marble.kde.org/" in Marble quickstart files (English and translations).

The bad url is not use in Overviews.