### PR TITLE
Trying to fix build pages error in Deploy pages CI

### DIFF
--- a/ci/build-pages.sh
+++ b/ci/build-pages.sh
@@ -5,7 +5,7 @@
 # Main configuration
 # ------------------------------------------------------------------------------
 
-cmake -DHTML=ON -DFI=ON -DIT=ON -DJA=ON -DES=ON -DFR=ON -DDE=ON -DHU=ON -@OSGeoLiveDoc_DEBUG=ON ..
+cmake -DHTML=ON -DFI=ON -DIT=ON -DJA=ON -DES=ON -DFR=ON -DDE=ON -DHU=ON -DOSGeoLiveDoc_DEBUG=ON ..
 make
 cd ..
 bash scripts/clean-images.sh


### PR DESCRIPTION
I noticed that Deploy pages GitHub Action fails recently, so I am trying to fix this issue now.
https://github.com/OSGeo/OSGeoLive-doc/runs/2338644669?check_suite_focus=true
```
CMake Error: Unknown argument -@OSGeoLiveDoc_DEBUG=ON
CMake Error: Run 'cmake --help' for all supported options.
make: *** No targets specified and no makefile found.  Stop.
```