### PR TITLE
Deleted nabble from contact

### DIFF
--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -26,9 +26,6 @@ Community Support
 If you have any questions, comments, or run into any problems, please drop us a
 note on `our mailing list <https://lists.osgeo.org/mailman/listinfo/osgeolive>`_.
 
-Searchable archives of the mailing list are hosted by
-`Nabble <http://www.osgeo-org.1560.x6.nabble.com/OSGeoLive-f3777350.html>`_.
-
 IRC users might try the #osgeolive or #osgeo channel at Freenode.net for real-time
 assistance. You also can meet us at Slack, Matrix or Glitter.
 


### PR DESCRIPTION
Check Documentation Links action failed due to nabble link,
https://github.com/OSGeo/OSGeoLive-doc/runs/3776701051?check_suite_focus=true#step:7:296

and it seemed to shut down,
https://www.osgeo.org/foundation-news/osgeo-nabble-forum-is-shutting-down/

so I deleted nabble link from `contact.rst`.