### PR TITLE
[locale] Automatic generation of locale files

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - master
+      - testtransifex
 
 jobs:
   deploy:
@@ -33,13 +34,40 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r ./requirements.txt
 
+      # This section updates the gh-pages
       - name: Build pages
         run: |
           mkdir build
-          cd build
-          bash ../ci/build-pages.sh
+          bash ci/build-pages.sh
+
+      # This section updates the locale
+      - name: Extract commit hash
+        if: github.ref == 'refs/heads/testtransifex'
+        run: |
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "GIT_HASH=$git_hash" >> $GITHUB_ENV
+
+      - name: Initialize mandatory git config
+        if: github.ref == 'refs/heads/testtransifex'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update locale                                                                                             
+        if: github.ref == 'refs/heads/testtransifex'
+        run: |                                                                                                          
+          bash ci/update_locale.sh
+          # commit the changes
+          git diff --staged --quiet || git commit -m "Automatic update of locale files from commit ${{ env.GIT_HASH }}"
+          # Remove the unstaged changes
+          git restore .
+          git fetch origin testtransifex
+          git rebase origin/testtransifex
+          git push origin testtransifex
+
 
       - name: Deploy pages
+        if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/build-pages.sh
+++ b/ci/build-pages.sh
@@ -5,9 +5,13 @@
 # Main configuration
 # ------------------------------------------------------------------------------
 
+DIR=$(git rev-parse --show-toplevel)
+pushd "${DIR}" > /dev/null || exit
+pushd build > /dev/null || exit
 cmake -DHTML=ON -DFI=ON -DIT=ON -DJA=ON -DES=ON -DFR=ON -DDE=ON -DHU=ON -DOSGeoLiveDoc_DEBUG=ON ..
 make
-cd ..
+popd 
 bash scripts/clean-images.sh
 touch build/doc/_build/html/.nojekyll # needed for gh pages to keep dirs starting with _
 du -h build/doc/_build/html
+popd

--- a/ci/update_locale.sh
+++ b/ci/update_locale.sh
@@ -1,0 +1,36 @@
+# ------------------------------------------------------------------------------
+# GitHub Actions scripts 
+# Copyright(c) OSGeoLive Contributors
+#
+# Main configuration
+# ------------------------------------------------------------------------------
+
+DIR=$(git rev-parse --show-toplevel)
+pushd "${DIR}" > /dev/null || exit
+pushd build > /dev/null || exit
+
+# build the locale
+cmake -DLOCALE=ON ..
+make locale
+popd
+
+# clean .tx/config
+head -4 .tx/config > tmp.out && mv tmp.out .tx/config
+# update .tx/config to add all the new/missing resources or fixing old resources naming
+sphinx-intl update-txconfig-resources --locale-dir locale --pot-dir locale/pot --transifex-project-name osgeolive
+perl -pi -e 's/\[osgeolive\./\[o:osgeo:p:osgeolive:r:/' .tx/config
+# add the changes
+git add .tx/config
+
+# List all the files that need to be committed in build/doc/locale_changes.txt                                
+awk '/^Update|^Create/{print $2}' build/doc/locale_changes.txt > tmp && mv tmp build/doc/locale_changes.txt        # .po files
+cat build/doc/locale_changes.txt | perl -pe 's/(.*)en\/LC_MESSAGES(.*)/$1pot$2t/' >> build/doc/locale_changes.txt  # .pot files
+#cat build/doc/locale_changes.txt
+
+# Remove obsolete entries #~ from .po files
+scripts/remove_obsolete_entries.sh
+
+# Add the files, commit and push
+for line in `cat build/doc/locale_changes.txt`; do git add "$line"; done
+
+popd

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -98,7 +98,7 @@ if (LOCALE)
         "${CMAKE_CURRENT_BINARY_DIR}"
         "${CMAKE_SOURCE_DIR}/locale/pot"
 
-        COMMAND sphinx-intl update -d ${CMAKE_SOURCE_DIR}/locale -l en
+        COMMAND sphinx-intl update -d ${CMAKE_SOURCE_DIR}/locale -l en > locale_changes.txt
 
         #COMMAND sphinx-intl update-txconfig-resources --locale-dir ${CMAKE_SOURCE_DIR}/locale --pot-dir ${CMAKE_SOURCE_DIR}/locale/pot --transifex-project-name osgeolive
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -245,14 +245,50 @@ latex_documents = [
 # Linkcheck configuration, see http://sphinx.pocoo.org/latest/config.html#options-for-the-linkcheck-builder
 
 linkcheck_ignore = [
+        # link changed name to https://geops.ch
+        # mostly used on the contibutors list. 
+        # TODO need to verify the change is correct
+        r'https://geops.de',
+
+        # The project you're trying to access has been archived.
+        # TODO Verify what happened to gmt because its for gmt_overview and gmt_quickstart
+        r'https://gmt.soest.hawaii.edu',
+
+        # TODO verify what happened to the archive
+        r'https://live.osgeo.org/archive',
+
+        # currently SSL_ERROR_BAD_CERT_DOMAIN
+        # TODO remove this line when the CERT is fixed
+        r'https://www.rspatial.org',
+
+        # bad gateway
+        # TODO remove line when page is reachable
+        'https://demo.pycsw.org/',
+
+        # Leaflet moved the documentation temporarly due to the Ucrania situation
+        # TODO hope for the war to be over and remove this line
+        r'https://leafletjs.com',
+
         # link exists but does not accept robots and linkchecker is a robot
         # used in overview/mapserver_overview
         'http://www.dnr.state.mn.us/maps/compass.html',
 
         # Link does not exist anymore
         # Used in overview/liblas_overview
+        # TODO remove link from documentation
         'https://www.asprs.org/divisions-committees/lidar-division/laser-las-file-format-exchange-activities.html',
 
+        # Link changed locations
+        # TODO change to https://saga-gis.sourceforge.io
+        r'http://www.saga-gis.org',
+        # TODO change to https://52north.org/research/scope/geospatial-sensing/
+        'https://52north.org/research/research-labs/sensor-web/',
+        # TODO change to https://cesium.com/learn/
+        'https://cesium.com/docs',
+        # TODO change to https://github.com/geoext/geoext
+        r'https://github.com/geoext/geoext3',
+        # TODO change to https://inspire.ec.europa.eu/validator/home/index.html
+        'https://inspire.ec.europa.eu/validator/about/',
 
         # links to the disk internals
         r'http://localhost', r'https://localhost',

--- a/locale/README.md
+++ b/locale/README.md
@@ -1,97 +1,69 @@
 
 # Locale
 
-**Warning** for administrators only
+## new/modified resource
 
-**Note** Different versions of sphinx-intl change the `pot` and `po` files structure even with the same content
+When a new rst file is been processed
 
-For generating the pot files v0.9.10 of sphinx-intl is used
+* new 
+  * .tx/config needs to be created
+  * pot & english po files need to be created
+* update 
+  * pot & english po files need to be updated
 
-- Installing the tx client: https://docs.transifex.com/client/installing-the-client
-- Introduction to the client: https://docs.transifex.com/client/introduction
-- Sphinx-intl installation: https://pypi.python.org/pypi/sphinx-intl
-  ```
-  pip install sphinx-intl==0.9.10
-  pip show sphinx-intl
-  ```
-- Sphinx: http://www.sphinx-doc.org/en/stable/intl.html
+Note: This process is done automatically on the github actions
 
-
-Follow the steps in the order presented in this README
-
-## build the pot/po files
+### Manual change
 
 ```
+bash ci/update_locale.sh
+```
+
+## Download translations
+
+This is needed for translator reviewer to check & fix the sphinx build
+
+work on 2 terminals
+* one with the python environment on (termA)
+* other without python environment (termB)
+
+For this example we are using the french language
+
+Process:
+* Download based on percentage translated (from the root of the repository)
+
+```
+termB$ tx pull -l fr --minimum-perc=80 --skip
+```
+
+* Build localy on termA
+
+```
+mkdir -p build
 cd build
-rm -rf ../locale/en/LC_MESSAGES/*
-rm -rf *
-cmake  -DLOCALE=ON ..
-make locale > locale_log.txt
-cd ..
+cmake -DFR=ON ..
+make html-fr
 ```
 
-## Verifying changes
-
-### List .pot & .po files that changed
-```
-git diff --name-only | grep '\.po'
-```
-
-
-### Verify the changes on the config file for transifex
-```
-git diff .tx/config
-```
-
-## Push changed resources to transifex
-
-Transifex will catch the changes
-
-## Commit changes
+* Look for errors and fix on transifex
+Suppose errors were fixed on overview--52nSOS_overview then download only that resource
 
 ```
-git commit -a -m 'Updating the locale'
+tx pull -l fr -r osgeolive.overview--52nSOS_overview
 ```
 
-## Pull transtlated strings
+Repeat until the most amount of errors could be fixed
 
-One file regardles of translation completition, normally used while translating.
+## commit push and make a PR.
 
-**Note:** Don't commit incomplete translations
+Please commit your work and push
 ```
-tx pull -r osgeolive.overview--52nSOS_overview -l fr
+git add locale/fr
+git commit -m '[fr] adding french translations'
+git push
 ```
+note make sure the commit message has the language enclosed in square braquets.
 
-All the 100% translated files of French language.
-* Takes time
-* This you can commit and make a PR
-```
-tx pull -l fr --minimum-perc=100 --skip
-```
+Make a Pull Request.
+Further fixes are going to be done by the OSGeoLive team.
 
-## clean the build & build the documentation:
-
-Use capital letters for the language, this builds for French
-```
-cd build
-rm -rf *
-cmake  -DHTML=ON -DFR=ON..
-make
-cd ..
-```
-
-## when there is a new resource
-
-```
-sphinx-intl update-txconfig-resources --locale-dir locale --pot-dir locale/pot --transifex-project-name osgeolive
-git add .tx/config
-```
-`git add` the pot & po files of the new resource
-
-```
-# tx push -s -r osgeolive.<name_of_resource>
-# for example:
-tx push -s -r osgeolive.quickstart--commandline_quickstart
-```
-
-if doubt on name of resource inspect `tx/config` file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==1.6.5
-sphinx-intl==0.9.10
+sphinx-intl[transifex]==0.9.10
 sphinxjp.themes.revealjs
 transifex-client

--- a/transifex.yml
+++ b/transifex.yml
@@ -1,0 +1,9 @@
+git:
+  filters:
+    - filter_type: dir
+      file_format: PO
+      source_file_extension: po
+      source_language: en
+      source_file_dir: locale/en/LC_MESSAGES
+      # path expression to translation files, must contain <lang> placeholder
+      translation_files_expression: 'locale/<lang>/LC_MESSAGES'


### PR DESCRIPTION
Changes to be committed:
* .github/workflows/deploy-pages.yml: added automatic locale generation
* ci/build-pages.sh: some cleanup
* ci/update_locale.sh: The script called by deploy
* doc/CMakeLists.txt: Needed file for the process
* doc/conf.py: ignoring links with problems
* locale/README.md: updating for the current changes
* requirements.txt: needs the transifex version
* transifex.yml: This is needed for transifex to upload files automatically

the transifex.yml can only be tested after it is in master.
This will create commits from the actions like this one:
https://github.com/OSGeo/OSGeoLive-doc/commit/32d1bc6cb37e74be0b12ce372b04d76c49ed34ea
That will update the locale files needed for transifex when the rst file changes