### PR TITLE
Update GeoStyler Docs

### DIFF
--- a/doc/overview/geostyler_overview.rst
+++ b/doc/overview/geostyler_overview.rst
@@ -21,8 +21,8 @@ a fully-fledged StyleEditor including filters and scale denominators.
 
 Furthermore, @NAME_geostyler@ allows for the translation between multiple styling formats, i.e. SLD, OpenLayers, QGIS, Mapbox. Since we are
 following the concept of micro packages, these translators (we call them parsers) can be used as standalone libraries, without the need to
-include the UI components as a dependency. Currently we have parsers for SLD, QGIS-styles, Mapbox styles and OpenLayers styles. Parsing of
-Mapfiles is in the works. Please take a look at StyleParser Implementations. Since attributively styling geodata is easier when you can look
+include the UI components as a dependency. Currently we have parsers for SLD, QGIS-styles, Mapbox styles, OpenLayers styles and Mapfiles.
+Please take a look at StyleParser Implementations. Since attributively styling geodata is easier when you can look
 at the data to be styled, we can connect to several datasources like WFS, Shapefiles and GeoJSON files. We plan on developing a data reader for
 the Geopackage format.
 

--- a/doc/quickstart/geostyler_quickstart.rst
+++ b/doc/quickstart/geostyler_quickstart.rst
@@ -109,7 +109,7 @@ Afterwards, we are able to read an existing SLD into the GeoStyler-readable form
                                 '</sld:UserStyle>' +
                             '</sld:NamedLayer>' +
                         '</sld:StyledLayerDescriptor>')
-        .then(style => console.log(style));
+        .then(style => console.log(style.output));
 
 
 To connect this style with the UI, we have to store it in a state variable and pass it to
@@ -140,7 +140,7 @@ our ``Style`` component. After defining ``myStyle`` as a state variable, you can
                                 '</sld:UserStyle>' +
                             '</sld:NamedLayer>' +
                         '</sld:StyledLayerDescriptor>')
-        .then(style => this.setStyle({myStyle}));
+        .then(style => this.setStyle({myStyle: style.output}));
 
     // ...
 
@@ -179,7 +179,7 @@ of the geostyler-sld-parser within the ``onStyleChange()`` method of the ``Style
                                 '</sld:UserStyle>' +
                             '</sld:NamedLayer>' +
                         '</sld:StyledLayerDescriptor>')
-        .then(style => this.setStyle({myStyle}));
+        .then(style => this.setStyle({myStyle: style.output}));
 
     // ...
 
@@ -188,7 +188,7 @@ of the geostyler-sld-parser within the ``onStyleChange()`` method of the ``Style
         style={myStyle}
         onStyleChange={gsStyle => {
             parser.writeStyle(gsStyle)
-                .then(sld => console.log(sld));
+                .then(sld => console.log(sld.output));
         }}
     />
 

--- a/projects_info.csv
+++ b/projects_info.csv
@@ -21,7 +21,7 @@ Y | geonode | 3.1.0 | Y | Y | Browser Facing GIS | | Geospatial Content Manageme
 Y | mapbender | 3.2.3 | Y | Y | Browser Facing GIS | | Geoportal Framework | mapbender | https://mapbender.org | OSGeo_project | Mapbender | Y
 Y | openlayers | 6.5.0 | Y | Y | Browser Facing GIS | | Browser Mapping Library | openlayers | https://openlayers.org/ | OSGeo_project | OpenLayers | Y
 #   OSGeo Community | | | | | | | | | | | |
-Y | geostyler | 4.6.0 | Y | Y | Browser Facing GIS | | Generic Styler For Geodata | GeoStyler | https://geostyler.org | OSGeo_community | GeoStyler | Y
+Y | geostyler | 9.0.0 | Y | Y | Browser Facing GIS | | Generic Styler For Geodata | GeoStyler | https://geostyler.org | OSGeo_community | GeoStyler | Y
 #   Others  | | | | | | | | | | | |
 Y | cesium | 1.80 | Y | Y | Browser Facing GIS | | 3D globes and 2D maps in a browser | cesiumjs | https://cesium.com/ | | Cesium | Y
 Y | geoext | 3.1.0 | Y | Y | Browser Facing GIS | | JavaScript Toolkit Web Mapping | geoext3 | https://geoext.github.io/geoext3 | | GeoExt | Y


### PR DESCRIPTION
This updates the GeoStyler docs to reflect the latest changes.

GeoStyler update on OSGeoLive done in https://github.com/OSGeo/OSGeoLive/pull/337

Question: Are translations still created/edited via transifex, so that I do not have to integrate any updates to the `.po` files here directly?