### PR TITLE
Update transifex client from python to new go version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,14 @@ You might need to install `git` and `cmake` if they are not on your system yet.
    # Python requirements
    pip install -r requirements.txt
 
-1.2 Requirements for the presentation
+1.2 Transifex Client
+::
+   mkdir -p $HOME/bin/tx
+   cd $HOME/bin/tx
+   curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+   # restart terminal
 
+1.3 Requirements for the presentation
 ::
    sudo apt-get install cpanminus
    sudo cpanm Text::SimpleTable::AutoWidth

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ sphinx>=4.0.0
 sphinx-intl>=2.0.0
 sphinx-revealjs
 sphinx-intl[transifex]
-transifex-client


### PR DESCRIPTION
`tx status` doesn't work with current Python version,
```zsh
% tx status
tx ERROR: not enough values to unpack (expected 2, got 1)
```

and I noticed that current Python version is deprecated already and its EOL is soon (in 4 months).
https://docs.transifex.com/client/client-configuration
![current-transifex-client-eol](https://user-images.githubusercontent.com/629923/180639659-e6050494-1ab0-467a-aafd-b600506b2fc0.png)

About new Go version, I couldn't find both Ubuntu apt and macOS brew package at this moment, so I deleted current `transifex-client` line from `requirements.txt` then added the new Go version installation instruction to `README.md`.
https://github.com/transifex/cli#installation

(I set `$HOME/bin/tx` for installation target, because after installation, 3 files (`tx`, `LICENSE` and `README.md`) were generated.)