### PR TITLE
Remove virtualbox-guest-dkms from virtualization quickstart

### DIFF
--- a/doc/quickstart/virtualization_quickstart.rst
+++ b/doc/quickstart/virtualization_quickstart.rst
@@ -100,7 +100,7 @@ Now bootup the VM by clicking the **Start** (green arrow) button.
 
 * The OSGeo-Live virtual display (i.e., the window size) may be very small, and will not be able to increase until you install Guest Additions. You should install the virtualbox guest additions, this will allow you to use full-screen mode.
 
-  ``sudo apt-get install --yes virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11``
+  ``sudo apt-get install --yes virtualbox-guest-utils virtualbox-guest-x11``
 
 (Alternative) If the above command does not work, use the following alternative:
 


### PR DESCRIPTION
Hi @pjduplooy2022,

I created the following fix to this OSGeoLive-doc side, so could you check this ?
https://github.com/OSGeo/OSGeoLive/pull/344
> In the included docs under Running in a Virtual Machine, Step 3, the following sentence appears:
> 
> sudo apt-get install --yes virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11. This is done to enable guest additions in a Virtualbox Virtual Machine.
> 
> Package virtualbox-guest-dkms has been removed in Ubuntu LTS (Jammy).
> 
> This entry can be safely removed from instructions., so it should just read sudo apt-get install --yes virtualbox-guest-utils virtualbox-guest-x11

Thanks,