### PR TITLE
Update ETF documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -325,7 +325,7 @@ rst_epilog="""
 .. |FE| replace:: `Filter Encoding (FE) <https://www.ogc.org/standards/filter>`__
 .. |ISO19105| replace:: `ISO 19105 <https://committee.iso.org/sites/tc211/home/projects/projects---complete-list/iso-19105.html>`__
 .. |KML| replace:: `KML <https://www.ogc.org/standards/kml>`__
-.. |OGCAPIFEATURES| replace:: `OGC API-Features <https://www.ogc.org/standards/ogcapi-features>`__
+.. |OGCAPIFEATURES| replace:: `OGC API - Features <https://www.ogc.org/standards/ogcapi-features>`__
 .. |ORM| replace:: `OGC Reference Model (ORM) <https://www.ogc.org/standards/orm>`__
 .. |SENSORML| replace:: `Sensor Model Language (SensorML) <https://www.ogc.org/standards/sensorml>`__
 .. |SFS| replace:: `Simple Feature Access (SFS) <https://www.ogc.org/standards/sfs>`__

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -323,7 +323,9 @@ rst_epilog="""
 .. |CSW| replace:: `Catalogue Service for the Web (CSW) <https://www.ogc.org/standards/cat>`__
 .. |GML| replace:: `Geography Markup Language (GML) <https://www.ogc.org/standards/gml>`__
 .. |FE| replace:: `Filter Encoding (FE) <https://www.ogc.org/standards/filter>`__
+.. |ISO19105| replace:: `ISO 19105 <https://committee.iso.org/sites/tc211/home/projects/projects---complete-list/iso-19105.html>`__
 .. |KML| replace:: `KML <https://www.ogc.org/standards/kml>`__
+.. |OGCAPIFEATURES| replace:: `OGC API-Features <https://www.ogc.org/standards/ogcapi-features>`__
 .. |ORM| replace:: `OGC Reference Model (ORM) <https://www.ogc.org/standards/orm>`__
 .. |SENSORML| replace:: `Sensor Model Language (SensorML) <https://www.ogc.org/standards/sensorml>`__
 .. |SFS| replace:: `Simple Feature Access (SFS) <https://www.ogc.org/standards/sfs>`__

--- a/doc/overview/ETF_overview.rst
+++ b/doc/overview/ETF_overview.rst
@@ -71,12 +71,12 @@ Core Features
 
 * Implemented Standards
    - |CSW|
-   - ISO 19105
+   - |ISO19105|
    - |SOS|
    - |WFS|
    - |WMTS|
    - |GML|
-   - OGC API - Features
+   - |OGCAPIFEATURES|
    - |WCS|
    - |WMS|
 

--- a/doc/quickstart/ETF_quickstart.rst
+++ b/doc/quickstart/ETF_quickstart.rst
@@ -1,7 +1,7 @@
-:Author: Clemens Portele
-:Author: Jon Herrmann
 :Author: Marco Minghini
 :Author: Enrique Soriano
+:Author: Clemens Portele
+:Author: Jon Herrmann
 :License: Creative Commons Attribution (cc-by) 4.0
 :Thanks:
 
@@ -22,7 +22,7 @@ and web services in Spatial Data Infrastructures (SDIs). The design of ETF is
 driven by three goals: be user-friendly, consistent with the standards and
 capable of testing all resources in an SDI.
 
-This Quick Start describes how to:
+This Quickstart describes how to:
 
   * navigate through the web application
   * start a test
@@ -35,29 +35,29 @@ This Quick Start describes how to:
 Introduction
 ===============
 
-From the Start menu, select |osgeolive-appmenupath-ETF|. The application will
+From the OSGeoLive *Start* menu, select |osgeolive-appmenupath-ETF|. The application will
 take a few moments to start up and will open a web page at
 http://localhost:9090/ETF
 
-In the header, there is a menu with 4 options, each representing different views
+In the header, there is a menu with 4 sections, each representing different views
 and functionalities:
 
 .. image:: /images/projects/ETF/etf-introduction.png
 
-#. The first one is Start test. In this section all available (i.e. installed)
+#. The first one is **Start test**. In this section all available (i.e. installed)
    Executable Test Suites are listed. Within this section, an Executable Test
    Suite can be selected and run against a Test Object.
 
-#. The second one is Status. This one shows all tests that are currently being
+#. The second one is **Status**. This one shows all tests that are currently being
    executed on the system and allows to open a monitor view for single test runs
    to check the status of any running test. Moreover, the components currently
    loaded are shown below the running tests.
 
-#. The third one is Test reports. In this one the results of any completed test
+#. The third one is **Test reports**. In this one the results of any completed test
    can be checked, analysed in detail or downloaded.
 
-#. The fourth one is Help. This one is a link to the documentation. Inside it,
-   there are guides on how to use all functionalities of ETF.
+#. The fourth one is **Help**. This one is a link to the documentation. Inside it,
+   there are guides on how to use all functionalities of the ETF.
 
 
 
@@ -72,7 +72,7 @@ The landing view shows the available Executable Test Suites.
 .. image:: /images/projects/ETF/etf-test-suite-selection-1.png
 
 Additional information about a Test Suite can be accessed by clicking on the
-plus button.
+*+* button.
 
 .. image:: /images/projects/ETF/etf-test-suite-selection-2.png
 
@@ -85,17 +85,16 @@ This information:
   the Test Suite in a Test Run (Pre-requisite conformance classes).
 * May include the name of associated Tags which are used to group the Test
   Suites in the view.
-* The name of applicable Test Object Types (explained in the next section).
-* Includes general information like the version, author and last editor,
-  creation and change dates.
+* Includes the name of applicable Test Object Types (explained in the next section).
+* Includes general information like the version, author and last editor, creation and change dates.
 
 
-To start a Test Run, a Test Suite must be selected with a click on the use flip
+To start a Test Run, a Test Suite must be selected with a click on the *use* flip
 switch on the right-hand side.
 
 .. image:: /images/projects/ETF/ETF_screenshot.png
 
-A Start button appears once at least one Test Suite is selected.
+A *Start* button appears once at least one Test Suite is selected.
 
 A Test Suite is only applicable to certain Test Object Types, which are listed
 in the description. Multiple Test Suites can be selected for one Test Run, but
@@ -109,7 +108,7 @@ A Test Suite may depend on other Test Suites. The dependencies are also shown in
 the description of the Test Suites.  These dependencies are also automatically
 executed during the test run.
 
-A click on the Start button will open a new view that asks the user about the
+A click on the *Start* button will open a new view that asks the user about the
 target resource to be tested.
 
 
@@ -119,9 +118,9 @@ Test Run configuration
 
 .. image:: /images/projects/ETF/etf-test-run-configuration-1.png
 
-The Label field is mandatory and automatically preset with the current time and
-names of the selected Test Suites. The Label will be shown in the Test reports
-overview and can be changed in order to help find the report again after a test
+The *Label* field is mandatory and automatically preset with the current time and
+names of the selected Test Suites. The Label will be shown in the **Test reports**
+section and can be changed in order to help find the report again after a test
 run.
 
 The style of the view may depend on the selected Test Suites.
@@ -131,9 +130,9 @@ File-based Tests
 The following elements are shown when Test Suites have been selected that test
 one or multiple test data files.
 
-If File upload is selected as Data source, one or multiple local files can be
+If *File upload* is selected as *Data source*, one or multiple local files can be
 selected and uploaded to the ETF. The ETF only accepts files with XML and GML
-file ending and ZIP files containing these two file types.
+file extensions as well as ZIP files containing these two file types.
 
 .. note::	Other files, like schema definition files, cannot be used and are
   silently ignored by the ETF!
@@ -143,15 +142,15 @@ file ending and ZIP files containing these two file types.
 The maximum uploadable file size is displayed when the mouse is moved over the
 question mark.
 
-If the data are available on the web, they can be tested by providing one single
-URL. After Remote file (URL) has been selected as Data source, an URL to either
+If the data to be tested are available on the web, they can be tested by providing one single
+URL. After *Remote file (URL)* has been selected as *Data source*, a *Remote URL* to either
 one single XML, GML or a ZIP file can be entered.
 
 .. image:: /images/projects/ETF/etf-file-based-tests-2.png
 
 
 If the URL requires authentication, username and password can be provided by
-clicking on Credentials.
+clicking on *Credentials*.
 
 .. image:: /images/projects/ETF/etf-file-based-tests-3.png
 
@@ -163,37 +162,37 @@ Service Tests
 The following elements are shown when Test Suites have been selected that test
 one service.
 
-The URL of a service must be entered beginning with ``http://`` or ``https://``.
+The *Service URL* must be entered beginning with ``http://`` or ``https://``.
 
 .. image:: /images/projects/ETF/etf-service-test-1.png
 
 If the service requires authentication, username and password can be provided by
-clicking on Credentials.
+clicking on *Credentials*.
 
 Dependencies and Parameters
 ----------------------------------
 
-The Test Suites button shows some basic information about the selected Test
+The *Test Suites* button shows some basic information about the selected Test
 Suites and - if applicable - about the direct dependencies.
 
 .. image:: /images/projects/ETF/etf-dependencies-and-parameters-1.png
 
-If the Test accepts parameters, they are shown in the Test Suite Parameters
-section. Optional parameters can be displayed by clicking on the Optional
-Parameters button. A description of the parameters is displayed when the mouse
+If the Test accepts parameters, they are shown in the *Test Suite Parameters*
+section. Optional parameters can be displayed by clicking on the *Optional
+Parameters* button. A description of the parameters is displayed when the mouse
 is moved over the question mark.
 
 .. note::	In most cases the preset default values can be used.
 
 .. image:: /images/projects/ETF/etf-dependencies-and-parameters-2.png
 
-Finally the test can be started by clicking on the Start button. The view then
-changes automatically to the Monitor View.
+Finally the test can be started by clicking on the *Start* button. The view then
+changes automatically to the *Monitor Test Run* view.
 
 Monitor test runs
 =================
 
-After a Test Run has been started the Monitor View is shown.
+After a Test Run has been started the *Monitor Test Run* view is shown.
 
 .. image:: /images/projects/ETF/etf-monitor-test-runs-1.png
 
@@ -202,51 +201,51 @@ The blue bar indicates the progress.
 .. image:: /images/projects/ETF/etf-monitor-test-runs-2.png
 
 The console area shows information and result messages. The Test Run can be
-canceled with a click on the Cancel button.
+canceled with a click on the *Cancel* button.
 
-The view can be left, for instance with the X Button in the upper left corner.
+The view can be closed, for instance with the *X* Button in the upper left corner.
 Also when the browser is closed, the Test Run execution continues on the server.
 
-To reopen the Monitor View after it has been closed, select in the menu bar the
-Status view. The Status view shows all running tests. A click on the Test Run
-opens the Monitor View of that Test Run.
+To reopen the *Monitor Test Run* view after it has been closed, select in the menu bar the
+**Status** section. The **Status** section shows all running tests. A click on the Test Run
+opens the *Monitor Test Run* view of that Test Run.
 
 .. image:: /images/projects/ETF/etf-monitor-test-runs-3.png
 
-When a Test Run finishes and the Monitor View is opened, the Test Report is
+When a Test Run finishes and the *Monitor Test Run* view is opened, the Test Report is
 displayed automatically.
 
 
 Test Reports
 ============
 
-The Test Reports view shows all reports that have been generated from Test Runs.
+The **Test Reports** section shows all reports that have been generated from Test Runs.
 
 .. image:: /images/projects/ETF/etf-test-reports-1.png
 
-By clicking on the plus button information, about the start time, the test
+By clicking on the *+* button information for a Test Run, the start time, the test
 result status, the name of the Test Object and the used Test Suites are shown.
 
-A Test Report can be opened again by clicking on Open report or can be
-downloaded as HTML file by clicking on the Download button.
+A Test Report can be opened again by clicking on the *Open report* button or can be
+downloaded as HTML file by clicking on the *Download report* button.
 
-The log file of the test run can be inspected with the Open log button. By
-clicking on the Delete report button, the report will be deleted permanently.
+The log file of the test run can be inspected with the *Open log* button. By
+clicking on the *Delete report* button, the report will be deleted permanently.
 
 
 Inspect test reports
 ====================
 
 The top of a Test Report shows general information including the overall test
-result Status, the start time, the duration and a table, which summarizes the
+result status, the start time, the duration and a table, which summarizes the
 status of all tests on several levels.
 
 .. image:: /images/projects/ETF/etf-inspect-test-reports-1.png
 
-The Test Reports are interactive. The Show switch can be used to filter Only
-failed or Only manual tests. All deactivates the filter.
+The Test Reports are interactive. The *Show* switch can be used to filter *Only
+failed* or *Only manual* tests. The option *All* deactivates the filter.
 
-The Level of detail switch is used to show additional technical information in
+The *Level of detail* switch is used to show more or less information in
 the reports.
 
 .. image:: /images/projects/ETF/etf-inspect-test-reports-2.png
@@ -254,8 +253,8 @@ the reports.
 The test results are summarized hierarchically in a report. At the top level
 there are the Test Suites.
 
-By clicking on one test suite, a description and all lower level tests in that
-test suite are shown. Failures in a test suite can be immediately recognized by
+By clicking on one Test Suite, a description and all lower level tests in that
+Test Suite are shown. Errors in a Test Suite can be immediately recognized by
 the red color. The number of failed tests is shown in the top-right corner.
 
 .. image:: /images/projects/ETF/etf-inspect-test-reports-3.png
@@ -267,7 +266,7 @@ another test that has failed. The exact status can be found below the
 description.
 
 The number of levels depends on the tested Test Object. If service tests have
-been executed the hierarchy is as follows:
+been executed, the hierarchy is as follows:
 
 * Executable Test Suites
 * Test Modules (bundles Test Cases)
@@ -278,20 +277,19 @@ been executed the hierarchy is as follows:
 In a file-based test, Test Modules and Test Steps do not exist and are not shown
 in the report.
 
-Each test provides a description on how aspects are tested and lists the
-requirements. The test may possess a link to an abstract test suite, from which
-the test has been derived (Source).
+Each test lists the requirements and provides a description on how they are tested. The test may include a link to an Abstract Test Suite, from which
+the test has been derived (*Source*).
 
 .. image:: /images/projects/ETF/etf-inspect-test-reports-4.png
 
 Assertions stand for atomic test queries on the lowest level. Failed, red
-colored assertions display error messages in the Messages section.
+colored assertions display error messages in the *Messages* section.
 
 .. image:: /images/projects/ETF/etf-inspect-test-reports-5.png
 
 Helpful information may also be found on the next higher level, like for
-instance the response from a service on the Test Step level (note the Open saved
-response link in the report).
+instance the response from a service on the Test Step level (note the *Open saved
+response* link in the report).
 
 .. image:: /images/projects/ETF/etf-inspect-test-reports-6.png
 
@@ -301,22 +299,19 @@ Resources
 Using the instructions provided above, please find below a predefined set of
 resources that you can test in the ETF:
 
-
 * GML data sets: some predefined data sets can be downloaded from `here
-  <https://github.com/etf-validator/OSGeoLive-ETF/tree/main/resources/GML-data-sets>`__ .
+  <https://github.com/etf-validator/OSGeoLive-ETF/tree/main/resources/GML-data-sets>`__.
 * WMS services: a list of services is available `here
   <https://github.com/etf-validator/OSGeoLive-ETF/tree/main/resources/WMS-services>`__.
 * WFS services: a list of services is available `here
   <https://github.com/etf-validator/OSGeoLive-ETF/tree/main/resources/WFS-services>`__.
 
-.. note::	Some of the resources do not pass all the tests, so you can try to fix
-   them before validating them again
+.. note::	Some of the GML data sets provided above do not pass all the tests, so you can try to fix them (based on the errors reported in the test report) before validating them again until all tests succeed.
 
 What's next?
 ============
 
-This was just a very brief overview of the ETF.  There is more information in
-the demo installation and on the `ETF GitHub space`_.
+This was just a very brief overview of the ETF. There is more information in the demo installation and on the `ETF GitHub space`_.
 
 .. _ETF GitHub space: https://github.com/etf-validator
 


### PR DESCRIPTION
Overview: include abbreviations for links in the .rst and also in conf.py for OGC API - Features and ISO 19105 (hope we did it right @cvvergara )
Quickstart: small format adaptations and typos