### PR TITLE
Remove MapServer doc version number and https

### DIFF
--- a/doc/overview/mapserver_overview.rst
+++ b/doc/overview/mapserver_overview.rst
@@ -102,7 +102,7 @@ Demo
 Documentation
 --------------------------------------------------------------------------------
 
-* `MapServer Documentation <//localhost/mapserver/doc/index.html>`__
+* `MapServer Documentation <http://localhost/mapserver/doc/index.html>`__
 
 Details
 --------------------------------------------------------------------------------

--- a/doc/overview/mapserver_overview.rst
+++ b/doc/overview/mapserver_overview.rst
@@ -102,7 +102,7 @@ Demo
 Documentation
 --------------------------------------------------------------------------------
 
-* `MapServer 7.0 Documentation <https://localhost/mapserver/doc/index.html>`__
+* `MapServer Documentation <//localhost/mapserver/doc/index.html>`__
 
 Details
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Docs are now 7-4 (but will make a new pull request to update these to 7-6). It probably makes sense to leave a generic link to docs to avoid having to update this manually each time?

Also change from `https://` to `//` as this returns "Unable to Connect" within OSGeoLive (only `http` seems to work).

However I'm unsure how this localhost link is converted to work on the web site at https://live.osgeo.org/en/overview/mapserver_overview.html