### PR TITLE
Update Appveyor build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,8 @@ after_test:
   - 7z a osgeolive-doc.zip ./build/doc/_build/html/* > nul
 
 # Uncomment to enable debugging on the server
-#on_finish:
-#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))  
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))  
 
 artifacts:
   - path: osgeolive-doc.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,13 @@
-image: Visual Studio 2017
+image: Visual Studio 2022
 
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
   - C:\strawberry
 
 environment:
-  VS_VERSION: Visual Studio 15 2017
   matrix:
   - platform: x64
-    PYTHON: "C:\\Python37-x64"
+    PYTHON: "C:\\Python310-x64"
 
 matrix:
   fast_finish: true
@@ -20,7 +19,7 @@ install:
 
 build_script:
 
-  - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
+  - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvars64.bat"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   # using strawberryperl
@@ -47,11 +46,11 @@ deploy: off
 
 after_test:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - 7z a osgeolive-doc.zip ./build/doc/_build/html/* > nul
+  - 7z a osgeolive-doc.zip ./build/_build/html/* > nul
 
 # Uncomment to enable debugging on the server
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))  
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))  
 
 artifacts:
   - path: osgeolive-doc.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
 
 build_script:
 
-  - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvars64.bat"
+  - if "%platform%" == "x64" call "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvars64.bat"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   # using strawberryperl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ cache:
   - C:\strawberry
 
 environment:
+  VS_VERSION: Visual Studio 17 2022 # required for later CMake build
   matrix:
   - platform: x64
     PYTHON: "C:\\Python310-x64"


### PR DESCRIPTION
The Appveyor build script is useful for showing how to build the docs on Windows using Visual Studio.
This pull request:

- Fixes a path so the zip file is created successfully (Appveyor CI currently failing without this)
- Updates Visual Studio from 2017 to 2022
- Updates from Python 3.7 to Python 3.10