### PR TITLE
Automatic menuselection statement

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -26,6 +26,7 @@ set(OSGeoLiveDoc_SUBDIRS
     )
 
 
+  file(READ ${CMAKE_SOURCE_DIR}/menuselections.conf OSGeoLiveDoc_menuselections)
 
 #---------------------------------------------
 # Adding the documentation subdirectories & files

--- a/doc/_themes/overview/static/osgeolive.css
+++ b/doc/_themes/overview/static/osgeolive.css
@@ -51,7 +51,7 @@ h1 {
 }
 
 h2 {
-	font-size:1.5em;	
+	font-size:1.5em;
 }
 
 /* for consistency with "div.admonition, div.warning" from sphinxdoc.css (".. note::" and ".. warning::") */
@@ -149,4 +149,21 @@ p a:hover{
 	font-size:10pt;
 	padding:6px 10px 10px 0px;
 	clear:both;
+}
+
+.menuselection {
+  background-color:#C0C0C0;
+}
+
+.guilabel {
+  background-color: #e7e7e7;
+  border-radius: 12px;
+  border: 2px solid #808080;
+  color: black;
+  padding: 5px 3px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  margin: 4px 2px;
+  cursor: pointer;
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -212,30 +212,10 @@ linkcheck_ignore = [
         # Used in sponsors.rst
         'https://www.ntua.gr/en',
 
-        # Used in overview/inspire_overview
-        # Error message: broken    https://etf-validator.net - 503 Server Error: Service Temporarily Unavailable for url: https://etf-validator.net/
-        'https://etf-validator.net',
-
-        # Link does not exist anymore
-        # Used in quickstart/geoserver_quickstart
-        r'http://prj2epsg.org',
-
-        # Link with error 404 Client Error
-        # Used in quickstart/hyperv_quickstart
-        r'https://www.microsoft.com/en-us/download',
-
-        # Link does not exist anymore
-        # Used in quickstart/mapslicer_quickstart
-        'https://maps.yahoo.com/',
-
         # Link with certiciate problems
         # Used in quickstart/liblas_quickstart
-        'https://epsg.org/home.html',
+        #'https://epsg.org/home.html',
         'https://www.epsg.org/',
-
-        # Link with error 400 Client Error
-        # Used in contact
-        r'https://mobile.twitter.com/osgeolive',
 
         # Link to the presentation
         r'presentation.html'
@@ -310,6 +290,8 @@ rst_epilog="""
 .. |SUPPORT| replace:: `OSGeo service providers <https://www.osgeo.org/service-providers>`__
 .. |CC BY 3.0| replace:: `CC BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`__
 .. |CC BY-SA 3.0| replace:: `Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0) <https://creativecommons.org/licenses/by-sa/3.0/>`__
+@OSGeoLiveDoc_menuselections@
+
 
 @OSGeoLiveDoc_PROJECTS_LOGOS@
 @OSGeoLiveDoc_PROJECTS_VERSIONS@""" % {

--- a/doc/quickstart/52nSOS_quickstart.rst
+++ b/doc/quickstart/52nSOS_quickstart.rst
@@ -32,7 +32,7 @@ This Quick Start describes how to:
 Getting Started
 ===============
 
-1. Select :menuselection:`Geospatial --> Web Services --> 52North --> Start 52North SOS` to start the 52°North SOS.
+1. Select :|menu_52nSOS-Start| to start the 52°North SOS.
 
 This will open the 52°North SOS client welcome page in firefox at
    http://localhost:8080/52nSOS/ (see Fig. 1).

--- a/doc/quickstart/52nWSS_quickstart.rst
+++ b/doc/quickstart/52nWSS_quickstart.rst
@@ -9,7 +9,7 @@
 @VMDK_52nWSS@
 
 
-  
+
 ********************************************************************************
 @NAME_52nWSS@ Quickstart
 ********************************************************************************
@@ -35,14 +35,14 @@ For this OSGeoLive distribution, the 52°North WSS is already set up to protect 
 
 To get a list of protected services follow these steps:
 
-#. Go to :menuselection:`Geospatial --> Web Services --> 52North --> Start 52North WSS` to start the 52°North WSS or use this `direct link <http://localhost:8080/wss/site/manage.html>`_.
-  
+#. Go to :|menu_52nWSS-Start| to start the 52°North WSS or use this `direct link <http://localhost:8080/wss/site/manage.html>`_.
+
 #. The 52°North WSS management interface will open in a browser window. Click *Manage WSS* (**1**) to get a list of those services, that can be connected using the WSS.
 
    .. image:: /images/projects/52nWSS/52nWSS_start_manager.png
      :scale: 70 %
-     
-.. tip:: 
+
+.. tip::
   If it's requested, authenticate as user/user
 
 
@@ -57,7 +57,7 @@ The table has the following columns:
      :scale: 70 %
 
 * Enforcement Point Identifier
- 
+
 * Protected OGC Service base URL
 
 * OGC Service Type
@@ -71,7 +71,7 @@ The table has the following columns:
 Secure a WMS
 ================================================================================
 
-In this section we're going to protect a local WMS instance. 
+In this section we're going to protect a local WMS instance.
 
 
 Create a new enforcement point
@@ -102,9 +102,9 @@ Create a new enforcement point
 
 
 Create a new user
---------------------------------------------------------------------------------     
-     
-#. Open a new terminal emulator by selecting the menu option :menuselection:`Applications --> Accessories --> Terminal Emulator` 
+--------------------------------------------------------------------------------
+
+#. Open a new terminal emulator by selecting the menu option :menuselection:`Applications --> Accessories --> Terminal Emulator`
 
 #. Edit the file :file:`users.xml` present at the directory :file:`/var/lib/tomcat6/webapps/wss/WEB-INF/classes/`::
 
@@ -133,7 +133,7 @@ Now we will set up the following access policies for the newly protected WMS:
 
 * User `livedvd` -> Full access to all the layers from the WMS
 * Users `bob` and `guest` -> Access only to the layer `tasmania`
-* Other users -> Access not authorized to the WMS 
+* Other users -> Access not authorized to the WMS
 
 #. Return to the terminal emulator window.
 
@@ -185,7 +185,7 @@ In order to load the users and permissions changes, it's necessary to restart th
 Load a protected OGC Service
 ================================================================================
 
-In order to request the capabilities of the protected Geoserver WMS, follow the next steps:  
+In order to request the capabilities of the protected Geoserver WMS, follow the next steps:
 
 #. Type http://localhost:8080/wss/service/geoserver_localhost/httpauth?SERVICE=WMS&REQUEST=GetCapabilities in a browser
 
@@ -201,7 +201,7 @@ In order to request the capabilities of the protected Geoserver WMS, follow the 
 To further test the protected service, load http://localhost:8080/wss/service/geoserver_localhost/httpauth as WMS into any desktop mapping client that supports HTTP
 Basic Authentication. Follow the next steps for :doc:`QGis <../overview/qgis_overview>`:
 
-#. From the start menu, select :menuselection:`Geospatial --> Desktop GIS --> Quantum GIS` 
+#. From the start menu, select :menuselection:`Geospatial --> Desktop GIS --> Quantum GIS`
 
 #. The application will take a few seconds to start (a splash screen is shown while loading)
 

--- a/doc/quickstart/R_quickstart.rst
+++ b/doc/quickstart/R_quickstart.rst
@@ -22,7 +22,7 @@ This Quick Start describes how to:
   * load some data from a shapefile and map it
   * do a coordinate transformation
   * plot some data points on a map
-  
+
 .. contents:: Contents
    :local:
 
@@ -31,13 +31,13 @@ Start R
 =======
 R is essentially a command-line program, although graphical user
 interfaces are available. You type a line of code at the prompt,
-press return, and the R interpreter evaluates it and prints the 
+press return, and the R interpreter evaluates it and prints the
 result.
 
 .. Tip:: Don't fear the command line - it is a source of great power. Using the up and down arrows
    to recall commands so you can edit mistakes. Hit CTRL-C if get stuck and you should get the prompt back.
 
-Choose :menuselection:`Geospatial --> Spatial Tools --> R Statistics`. A terminal window opens running R.
+Choose |menu_R Statistics|. A terminal window opens running R.
 
 You can start with simple arithmetic.
 
@@ -60,7 +60,7 @@ A full range of arithmetic, trigonometric, and statistical
 functions are built-in, and thousands more are available from
 packages in the `CRAN <https://cran.r-project.org/>`_ archive.
 
-The main prompt in R is ``>``, but there is also the continuation prompt ``+``, which 
+The main prompt in R is ``>``, but there is also the continuation prompt ``+``, which
 appears if R expects more input to make a valid expression. You'll see this if you
 forget a closing bracket or parenthesis.
 
@@ -75,10 +75,10 @@ forget a closing bracket or parenthesis.
 Building data
 =============
 
-You might be wondering what the mysterious 'one' in square brackets is 
+You might be wondering what the mysterious 'one' in square brackets is
 doing in the output. This is telling you that the result is one number. R
 can store things in one-dimensional vectors, two-dimensional matrices,
-and multi-dimensional arrays. There are many functions that can 
+and multi-dimensional arrays. There are many functions that can
 generate these things. Here's a simple sequence:
 
 ::
@@ -88,7 +88,7 @@ generate these things. Here's a simple sequence:
     [9] 4.555556 5.000000
 
 Now you can see that the ``[9]`` is telling us that 4.555 is the ninth
-value in the vector. 
+value in the vector.
 
 If you construct a matrix you get row and column labels:
 
@@ -101,7 +101,7 @@ If you construct a matrix you get row and column labels:
 	[2,]    2    5    8   11
 	[3,]    3    6    9   12
 
-Elements of matrices can be extracted using square brackets, with row and column 
+Elements of matrices can be extracted using square brackets, with row and column
 indices separated by commas. Leave an index blank to get a whole row as a vector. Use a vector
 index to get multiple rows or columns as a smaller matrix:
 
@@ -122,7 +122,7 @@ index to get multiple rows or columns as a smaller matrix:
 Data frames are data structures that mirror the kind of structure
 found in an RDBMS such as Postgres or MySQL. Each row can be thought
 of as a record, with columns being like fields in a database. As in a
-database, each field must be of the same type for each record. 
+database, each field must be of the same type for each record.
 
 In many ways they work like matrices, but you can also get and set the columns by name
 using $-notation:
@@ -131,17 +131,17 @@ using $-notation:
 
 	> d = data.frame(x=1:10, y=1:10, z=runif(10)) # z is 10 random numbers
 	> d
-	        x  y          z 
-	    1   1  1 0.44128080 
-	    2   2  2 0.09394331 
-	    3   3  3 0.51097462 
-	    4   4  4 0.82683828 
-	    5   5  5 0.21826740 
-	    6   6  6 0.65600533 
-	    7   7  7 0.59798278 
-	    8   8  8 0.19003625 
-	    9   9  9 0.24004866 
-	    10 10 10 0.35972749 
+	        x  y          z
+	    1   1  1 0.44128080
+	    2   2  2 0.09394331
+	    3   3  3 0.51097462
+	    4   4  4 0.82683828
+	    5   5  5 0.21826740
+	    6   6  6 0.65600533
+	    7   7  7 0.59798278
+	    8   8  8 0.19003625
+	    9   9  9 0.24004866
+	    10 10 10 0.35972749
 
 	> d$z
 	 [1] 0.44128080 0.09394331 0.51097462 0.82683828 0.21826740 0.65600533
@@ -174,7 +174,7 @@ There are many packages for spatial data manipulation and statistics. Some
 are included here, and some can be downloaded from CRAN.
 
 Here we will load two shapefiles - the country boundaries and populated places
-from the Natural Earth data. We use two add-on packages to get the spatial 
+from the Natural Earth data. We use two add-on packages to get the spatial
 functionality:
 
 ::
@@ -202,7 +202,7 @@ field to subset the world data and just get the UK:
 .. image:: /images/projects/R/r_plot2.png
 
 This looks a bit squashed to anyone who lives here, since we are more familiar with
-a coordinate system centred at our latitude. Currently the object doesn't have a 
+a coordinate system centred at our latitude. Currently the object doesn't have a
 coordinate system assigned to it.
 
 We need to assign a CRS to the object before we can
@@ -216,7 +216,7 @@ to EPSG:27700 which is the Ordnance Survey of Great Britain grid system:
 
 .. image:: /images/projects/R/r_plot2_1.png
 
-This plots the base map of the transformed data. Now we want to add some points from the 
+This plots the base map of the transformed data. Now we want to add some points from the
 populated place data set. Again we subset the points we want and transform them to
 Ordnance Survey Grid Reference coordinates:
 
@@ -226,25 +226,25 @@ Ordnance Survey Grid Reference coordinates:
 	> ukpop <- st_transform(ukpop,27700)
 
 
-We add these points to the base map, scaling their size by scaled square root of the 
+We add these points to the base map, scaling their size by scaled square root of the
 population (because that makes a symbol with area proportional to population), set the
 colour to red and the plotting character to a solid blob:
 
 ::
 
-    > ggplot() + 
+    > ggplot() +
     > 	geom_sf(data = ukos) + 								# add UK shape to the map
     > 	geom_sf(data = ukpop, 								# add the Populated places
     > 	        aes(size = ukpop$POP_MAX/100000), 			# fix size of points (by area)
     > 	        colour = 'red', alpha = 1/5) + 				# set points colour and transparency
     > 	coord_sf(crs = 27700, datum= sf::st_crs(27700), 	# set a bounding box
-    > 	         xlim = st_bbox(ukos[c(1,3)]),				# for the map	
+    > 	         xlim = st_bbox(ukos[c(1,3)]),				# for the map
     > 	         ylim = st_bbox(ukos[c(2,4)])
     > 	        ) +
     > 	ggtitle('Uk Population centre sizes') + 			# set the map title
     > 	    theme(legend.position = 'bottom') +				# Legend position
-    >		scale_size_area(name = 'Population \nin 100K')	# 0 value means 0 area + legend title 
- 
+    >		scale_size_area(name = 'Population \nin 100K')	# 0 value means 0 area + legend title
+
 
 and our final image appears:
 
@@ -269,6 +269,6 @@ For general information about R, try the official `Introduction to R <https://cr
 
 For more information on spatial aspects of R, the best place to start is probably the `R Spatial Task View <https://cran.r-project.org/web/views/Spatial.html>`_
 
-You might also want to check out the `R-Spatial <https://www.rspatial.org>`_ 
+You might also want to check out the `R-Spatial <https://www.rspatial.org>`_
 page.
 

--- a/doc/quickstart/_template_quickstart.rst
+++ b/doc/quickstart/_template_quickstart.rst
@@ -7,86 +7,152 @@
 @VMDK_slug@
 
 
-
 ********************************************************************************
 @NAME_slug@ Quickstart
 ********************************************************************************
 
-For more information about how to write this quickstart, see the 'How to document the quickstart file' on the osgeo wiki: https://trac.osgeo.org/osgeolive/wiki/How%20to%20document%20the%20quickstart%20file
+For more information about how to write this quickstart, see the 'How to
+document the quickstart file' on the osgeo wiki:
+https://trac.osgeo.org/osgeolive/wiki/How%20to%20document%20the%20quickstart%20file
 
 .. Note:: Writing tip: Overview section
-   This section is required and has no heading. Start with a sentence describing what the application is and does. Next, describe what will be covered in the Quickstart. 
-   
-   Choose a few features to show. If you're showing one or two things, write that in sentence format. If it's three or more, use a bullet list. 
-   
-   Mention any prerequisites that are required to complete the Quickstart, for example, internet connection or data to test with.
+   This section is required and has no heading. Start with a sentence describing
+   what the application is and does. Next, describe what will be covered in the
+   Quickstart.
+
+   Choose a few features to show. If you're showing one or two things, write
+   that in sentence format. If it's three or more, use a bullet list.
+
+   Mention any prerequisites that are required to complete the Quickstart, for
+   example, internet connection or data to test with.
 
 .. contents:: Contents
    :local:
 
-.. Note:: Writing tip: Contents list 
-   Use headings in your document to automatically generate a table of contents. The headings should start with verbs (action words), and should be the same or similar to what you have said the Quickstart will cover.
+.. Note:: Writing tip: Contents list
+   Use headings in your document to automatically generate a table of contents.
+   The headings should start with verbs (action words), and should be the same
+   or similar to what you have said the Quickstart will cover.
 
 Start application name
-======================
+===============================================================================
 .. Note:: Writing Tip:
-   The heading title for the first section is "Start application name". Use Sphinx inline markup :menuselection: for selecting the application from the Start menu or the desktop.
+   The heading title for the first section is "Start application name". Use
+   Sphinx inline markup :menuselection: for selecting the application from the
+   Start menu or the desktop.
 
-   If there is more than one step to get running with the application, use numbered steps. If it is only one step, use sentence format.
+   If there is more than one step to get running with the application, use
+   numbered steps. If it is only one step, use sentence format.
 
-From the Start menu, choose :menuselection:`Geospatial --> Desktop GIS --> application name`. The application will take a few moments to start up.
+From the Start menu, choose |menu_slug|. The application will take a few moments
+to start up.
 
    .. image:: /images/projects/<slug>/image_name.png
    :scale: 70 %
 
 .. Note:: Writing Tip:
-   Include a screenshot here of the UI. Use a scale of 50% from a 1024x768 display (preferred) or 70% from a 800x600 display. Markup the graphic with red circles to highlight any particular areas of note on the user interface (if required).
+   Include a screenshot here of the UI. Use a scale of 50% from a 1024x768
+   display (preferred) or 70% from a 800x600 display. Markup the graphic with
+   red circles to highlight any particular areas of note on the user interface
+   (if required).
    Store images here:
    https://github.com/OSGeo/OSGeoLive-doc/tree/master/images/projects/1024x768/
 
 
 Procedure
-=========
- 
-.. Note:: Writing Tip: Use numbered steps to describe what to do (the hash symbol renders numbered steps). Steps start with a verb (action word). 
-   
-   Include only one action per step. A description of the expected result is not a new step. Refer to the Google Developer Style guide if you need guidance: ​https://developers.google.com/style
-   
-   Use Sphinx inline markup such as :guilabel: for buttons and field names; and :menuselection: for selecting menu items. Also refer to this page to describe elements on the UI: https://developers.google.com/style/ui-elements
-   
-   Use sub-headings for nested procedures if required. Use code blocks to describe interactions with the command line.
-   
-   Images - include as many images as the user is about to experience. The reader should be able to read the quickstart without running the software, and understand from the screenshots what will happen.
-   
-#. Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+===============================================================================
+
+.. Note:: Writing Tip: Use numbered list to describe what to do (the hash
+   symbol renders numbered steps). Steps start with a verb (action word).
+
+   Include only one action per step. A description of the expected result is not
+   a new step. Refer to the Google Developer Style guide if you need guidance:
+   https://developers.google.com/style
+
+
+#. step 1
+   Description of step 1
+
+   ::
+
+     This code belongs to step 1
+
+#. step 2
+   Description of step 2
+
+.. Note:: Writing Tip: Use bullets
+
+* Bullet level 1: completely at the left
+* This is at Bullet level 1.
+
+  * Bullet level 2: Indented two spaces to the right with a line separating from
+    different bullet level
+  * This is at Bullet level 2.
+
+    * Bullet level 3: Indented two spaces to the right with a line separating
+      from different bullet level.
+
+  * Bullet level 2: its is a different bullet level so needs a separator
+    different bullet level
+
+
+Use Sphinx inline markup such as
+`:guilabel:` for buttons and field names; and
+`:menuselection:` for selecting menu items. Also refer to this page to describe
+    elements on the UI: https://developers.google.com/style/ui-elements
+
+This is a subheading
+-------------------------------------------------------------------------------
+
+Use sub-headings for nested procedures if required. Use code blocks to describe
+interactions with the command line.
+
+Images - include as many images as the user is about to experience. The reader
+should be able to read the quickstart without running the software, and
+understand from the screenshots what will happen.
+
+#. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 #. Mauris eget dui vitae estsodales consequat eget vel risus.
-#. Praesent pretium mauris id porta convallis.   
-   
+#. Praesent pretium mauris id porta convallis.
+
 ::
 
-   Code starts here, 
+   Code starts here,
    More code
 
-.. Note:: Writing Tip: Notes are optional. You can use them to provide descriptions and background information without getting in the way of instructions.
+.. Note:: Writing Tip: Notes are optional. You can use them to provide
+   descriptions and background information without getting in the way of
+   instructions.
 
-.. Tip:: Writing Tip: Tips are optional. You can use them to provide extra information or other ways of performing an action like keyboard shortcuts or drag and drop.
+.. Tip:: Writing Tip: Tips are optional. You can use them to provide extra
+   information or other ways of performing an action like keyboard shortcuts or
+   drag and drop.
 
 
 Things to try
-=============
+===============================================================================
+
 .. Note:: Writing tip:
-  This section is optional. Suggest one or several activities for people to try out on their own. It could be something very specific that is easily achievable, or it could be a bit of a challenge that involves a small bit of research (limited to something that can be found in documentation packaged on OSGeoLive.
+   This section is optional. Suggest one or several activities for people to try
+   out on their own. It could be something very specific that is easily
+   achievable, or it could be a bit of a challenge that involves a small bit of
+   research (limited to something that can be found in documentation packaged on
+   OSGeoLive.
 
 Here are some additional challenges for you to try:
 
-* Try Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+* Try Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 * Mauris eget dui vitae estsodales consequat eget vel risus.
 * Try Praesent pretium mauris id porta convallis.
 
 What next?
-==========
+===============================================================================
+
 .. Note:: Writing tip
-   This section is required. Provide links to any further documentation or tutorials. If your project has no further documentation, include a link to your project's website or wiki or include a contact email or mailing list to join.
+   This section is required. Provide links to any further documentation or
+   tutorials. If your project has no further documentation, include a link to
+   your project's website or wiki or include a contact email or mailing list to
+   join.
 
 Check out these other resources about this application.
 
@@ -95,4 +161,6 @@ Check out these other resources about this application.
 * Website
 
 
-For more information about how to write this quickstart, see the 'How to document the quickstart file' on the osgeo wiki: https://trac.osgeo.org/osgeolive/wiki/How%20to%20document%20the%20quickstart%20file
+For more information about how to write this quickstart, see the 'How to
+document the quickstart file' on the osgeo wiki:
+https://trac.osgeo.org/osgeolive/wiki/How%20to%20document%20the%20quickstart%20file

--- a/doc/quickstart/atlasstyler_quickstart.rst
+++ b/doc/quickstart/atlasstyler_quickstart.rst
@@ -14,7 +14,7 @@
 
 Manuals
 ================================================================================
-* `AtlasStyler manual, German, Created for version 1.2 <../../geopublishing/AtlasStyler_v1.2_DE_Handbuch_090601.pdf>`_  
+* `AtlasStyler manual, German, Created for version 1.2 <../../geopublishing/AtlasStyler_v1.2_DE_Handbuch_090601.pdf>`_
 
 Tutorials
 ================================================================================
@@ -32,17 +32,17 @@ Running
 Getting Started
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-AtlasStyler is an end-user based application, that allows you to create .SLD files for your vectordata. 
+AtlasStyler is an end-user based application, that allows you to create .SLD files for your vectordata.
 
-1) The OSGeoLive DVD uses the Lubuntu Operating system which has a temporary small problem with Java-based applications: As a solution please right-click on menu-bar (Where 'Applications' and 'Places' is listed) and select 'Customize Panel'. There check the 'Autohide' option. The menubar is now hidden unless your mouse reaches the top of the screen. 
+1) The OSGeoLive DVD uses the Lubuntu Operating system which has a temporary small problem with Java-based applications: As a solution please right-click on menu-bar (Where 'Applications' and 'Places' is listed) and select 'Customize Panel'. There check the 'Autohide' option. The menubar is now hidden unless your mouse reaches the top of the screen.
 
-#) Go to :menuselection:`Geospatial --> Desktop GIS --> AtlasStyler` to start the application.
- 
-#) Use the import buttons to either add ESRI Shapefiles oder PostGIS datasources to your project. 
+#) Go to |menu_atlasstyler|
+
+#) Use the import buttons to either add ESRI Shapefiles oder PostGIS datasources to your project.
 
 #) To import PostGIS, the correct database settings are already preset in the dialog. Just enter the password 'user' to add the 'ne_10m_land' layer.
 
-#) To import a Shapefile, choose '/home/user/data/natural_earth2/ne_10m_lakes.shp' for example. 
+#) To import a Shapefile, choose '/home/user/data/natural_earth2/ne_10m_lakes.shp' for example.
 
 #) Click the tool-icon in the layer legend and select style. The main AtlasStyler dialog will open. While you change the style, the 'automatic preview' option at the bottom will allow to see your changes on the fly. If the data is too big (or the system too slow) deactivate the 'automatic preview' checkbox.
 

--- a/doc/quickstart/cartaro_quickstart.rst
+++ b/doc/quickstart/cartaro_quickstart.rst
@@ -25,7 +25,7 @@
 @NAME_cartaro@ Quickstart
 ********************************************************************************
 
-Cartaro is a geo-enabled Content Management System (CMS) to manage and publish geospatial and non-geospatial content. 
+Cartaro is a geo-enabled Content Management System (CMS) to manage and publish geospatial and non-geospatial content.
 
 
 
@@ -33,12 +33,12 @@ This Quickstart will guide you through the following tasks:
 
 #. Create a new geospatial content type
 #. Configure Cartaro to display the new content type
-#. Add new geospatial content 
+#. Add new geospatial content
 
 All tasks will be performed using the example of a touristic web portal with the goal to map lakes.
 
 .. contents:: Contents
-  
+
 Starting Cartaro
 ================================================================================
 
@@ -50,7 +50,7 @@ Starting Cartaro
      hash.
 
 #. Start the OSGeoLive DVD
-#. Choose :menuselection:`Geospatial --> Browser Clients --> Start Cartaro` to start Cartaro
+#. Choose |menu_cartaro-Start|
 #. The Cartaro web page http://localhost/cartaro will automatically open
 
 .. Writing Tip:
@@ -75,7 +75,7 @@ When the Cartaro page is opened, you will see the screen below. The front page c
 .. image:: /images/projects/cartaro/cartaro_userpage.png
     :scale: 60 %
     :align: center
-  
+
 .. tip::  You can return to the front page anytime by click on the home icon in the upper left corner.
 
 
@@ -85,7 +85,7 @@ Creating a new Content type
 Content types and fields define the structure  of a specific content (e.g. the content type *Capital* contains the fields "name" and "location" to generate content elements for the respective capitals displayed on the map).
 To create a new content type, follow the steps below.
 
-* Choose :menuselection:`Structure --> Content types` on the menu bar and click on **Add content type** 
+* Choose :menuselection:`Structure --> Content types` on the menu bar and click on **Add content type**
 
 
 .. image:: /images/projects/cartaro/cartaro_addcontenttype.png
@@ -112,7 +112,7 @@ To create a new content type, follow the steps below.
 * Choose your field settings in the new window: Select the geometry type that describes the kind of geospatial information you want to store. Choose *Polygon* to follow our example.
 
 .. image:: /images/projects/cartaro/cartaro3.png
-    :scale: 70 % 
+    :scale: 70 %
     :align: center
 
 .. tip::  Read the text below the *Geometry type* drop-down box to find the geometry type that fits your needs.
@@ -120,16 +120,16 @@ To create a new content type, follow the steps below.
 * Finish by click on **Save field settings**
 
 .. image:: /images/projects/cartaro/cartaro4.png
-    :scale: 70 % 
+    :scale: 70 %
     :align: center
 
 * Press *Save settings* to finish the field creation
 
 .. image:: /images/projects/cartaro/cartaro5.png
-    :scale: 70 % 
+    :scale: 70 %
     :align: center
 
-* Under the tab *Manage fields* you could create further non-geospatial fields. We don't need to create a new one for our example. 
+* Under the tab *Manage fields* you could create further non-geospatial fields. We don't need to create a new one for our example.
 
 
 Configuring GeoServer
@@ -145,7 +145,7 @@ Configuring GeoServer
 
 Creating a new layer in GeoServer
 ``````````````````````````````````
-* Use GeoServer layers to publish your geospatial data. 
+* Use GeoServer layers to publish your geospatial data.
 * Choose :menuselection:`Structure --> GeoServer` from the menu bar to visit the GeoServer configuration page again
 * Select :menuselection:`Layers` and click **Add** to add a new layer
 
@@ -153,9 +153,9 @@ Creating a new layer in GeoServer
     :scale: 60 %
     :align: center
 
-#. Type a suitable layer title (e.g. lakes). 
-#. Select the layer type. We choose *PostGIS Field* for advanced geospatial operations and geodata storage. 
-#. As source select your created content type which will be associated with your new layer. 
+#. Type a suitable layer title (e.g. lakes).
+#. Select the layer type. We choose *PostGIS Field* for advanced geospatial operations and geodata storage.
+#. As source select your created content type which will be associated with your new layer.
 #. Make the checkmark  *Provide an OpenLayers WFS layer*  within the OpenLayers section.
 #. Finish configuration by click on **Save**
 
@@ -166,13 +166,13 @@ Creating a new layer in GeoServer
 
 * Congratulation! Your new GeoServer layer was added to GeoServer.
 
-.. tip:: You can now also access the geospatial fields of your content type via WFS or WMS with other applications (e.g. with :doc:`QGis <../overview/qgis_overview>`) 
+.. tip:: You can now also access the geospatial fields of your content type via WFS or WMS with other applications (e.g. with :doc:`QGis <../overview/qgis_overview>`)
 
 
 Configuring OpenLayers to activate your GeoServer layer in a map
 ================================================================================
 
-:doc:`OpenLayers <../overview/openlayers_overview>` is used to display your new layer on a map. You will now associate your GeoServer layer with your OpenLayers map. 
+:doc:`OpenLayers <../overview/openlayers_overview>` is used to display your new layer on a map. You will now associate your GeoServer layer with your OpenLayers map.
 
 * Go to :menuselection:`Structure --> OpenLayers --> Maps`  to visit the OpenLayers maps configuration page
 
@@ -182,13 +182,13 @@ Configuring OpenLayers to activate your GeoServer layer in a map
     :scale: 70 %
     :align: center
 
-* frontmap's configuration page appears as shown on the screenshot below. 
+* frontmap's configuration page appears as shown on the screenshot below.
 
 .. image:: /images/projects/cartaro/cartaro_openlayers_frontmapediting.png
     :scale: 70 %
     :align: center
 
-* Select :menuselection:`Layers & Styles` in the left sidebar to add our newly created layer to the frontmap. 
+* Select :menuselection:`Layers & Styles` in the left sidebar to add our newly created layer to the frontmap.
 
 * Look for your created GeoServer layer ('lakes' in our example)
 * Make checkmarks for *Enabled*, *Activated* and *In Switcher* to activate your new layer *lakes* in your map
@@ -210,13 +210,13 @@ After creating your content type and configuring GeoServer and OpenLayers you ca
     :scale: 70 %
     :align: center
 
-* Select **Add content** to add more content and choose your new content type in the appearing window (not shown). In the configuration page of your new content element (called node in Drupal language) make the following settings: 
+* Select **Add content** to add more content and choose your new content type in the appearing window (not shown). In the configuration page of your new content element (called node in Drupal language) make the following settings:
 
 #. Type a name
 #. You can draw the geometry for your content element. Choose the draw symbol on the upper right corner of the map. Note that tool tips are shown when you hover the toolbar icons. Click on the map to create a new geometry. Finish the drawing with double click.
 #. **Save** your geometry.
 
-.. note:: Only one geometry per content element can be drawn in our example configuration. Create additional content elements to add more polygons.  
+.. note:: Only one geometry per content element can be drawn in our example configuration. Create additional content elements to add more polygons.
 
 .. image:: /images/projects/cartaro/cartaro8.png
     :scale: 70 %
@@ -234,16 +234,16 @@ After creating your content type and configuring GeoServer and OpenLayers you ca
     :scale: 50 %
     :align: center
 
-Congratulations, you have just finished the quickstart tutorial. Your first content element is now ready. To add more content elements simply peform the steps of this section again. 
+Congratulations, you have just finished the quickstart tutorial. Your first content element is now ready. To add more content elements simply peform the steps of this section again.
 
 
 
 Things to Try
 ================================================================================
 
-* Use the **Layer Assistant** to include external layers :menuselection:`Structure --> Open Layers --> Layers --> Add using assistant`  
-* Change the default map behaviors and build your own map 
-* Try different geometry types and build more complex content types 
+* Use the **Layer Assistant** to include external layers :menuselection:`Structure --> Open Layers --> Layers --> Add using assistant`
+* Change the default map behaviors and build your own map
+* Try different geometry types and build more complex content types
 
 
 What Next ?
@@ -263,7 +263,7 @@ What Next ?
 .. Writing tip
   Provide links to further tutorials and other documentation.
 
-The quickstart has given a first impression about the possibilities of Cartaro to you. But there is a lot more to discover. 
+The quickstart has given a first impression about the possibilities of Cartaro to you. But there is a lot more to discover.
 
 
 Your next step may be to install Cartaro on your own servers. Just visit http://cartaro.org/documentation/getting-started to learn how.
@@ -276,4 +276,4 @@ Our documentation web page can be found here http://cartaro.org/documentation
 
     Available on http://cartaro.org
 
-                                                                      
+

--- a/doc/quickstart/deegree_quickstart.rst
+++ b/doc/quickstart/deegree_quickstart.rst
@@ -20,9 +20,9 @@
 geospatial web. *deegree* is a Java application for serving maps (and vector data) for other clients to show.
 
 Available components are:
- 
+
   * Web-Services: WFS, WMS, WMTS, CSW, WPS
-  
+
 *deegree 3* is the new generation of the deegree Java framework for GIS
 applications and OGC-service implementations.
 It can be used to build web-based geospatial-data-infrastructures (GDI).
@@ -33,10 +33,10 @@ It can be used to build web-based geospatial-data-infrastructures (GDI).
 Start deegree 3 webservices
 ===========================
 
-Choose *'Start deegree'* from the :menuselection:`Geospatial --> Web Services --> deegree` menu.
+Choose |menu_deegree-Start|.
 The application will take a few moments to start up.
 
-Firefox opens the *deegree 3 services console*. (You can also open this manually by pointing your browser to http://localhost:8033). 
+Firefox opens the *deegree 3 services console*. (You can also open this manually by pointing your browser to http://localhost:8033).
 This is a simple web-based GUI for editing the configuration files of the *deegree workspace*.
 
 Load a workspace
@@ -44,16 +44,16 @@ Load a workspace
 
 *deegree 3* uses configurations conformant to all *deegree 3* based webservices. Those configurations are stored in the workspace.
 
-#. To manage the included and ready-to-use workspaces, click *'workspaces'* on the left side. You are now in the workspace management of the running *deegree* instance. 
-   You can see which workspace is currently active (only one can be active at a time) workspace, inactive locally available workspaces and offical workspaces which can be imported if you have a internet connection. 
+#. To manage the included and ready-to-use workspaces, click *'workspaces'* on the left side. You are now in the workspace management of the running *deegree* instance.
+   You can see which workspace is currently active (only one can be active at a time) workspace, inactive locally available workspaces and offical workspaces which can be imported if you have a internet connection.
 #. Press start on the *deegree-workspace-utah-light*.
 
 The demo workspace contains a web mapping setup based on data from the state of Utah.
-It contains a WMS configuration (1.3.0 and 1.1.1) consisting of vector layers and a variety of render styles. 
+It contains a WMS configuration (1.3.0 and 1.1.1) consisting of vector layers and a variety of render styles.
 Additionally, a WFS (2.0.0, 1.1.0 and 1.0.0) is configured that allows to access the raw vector data, backed by shapefiles, in GML format.
 
 .. tip::
-   For additional configuration examples including raster data, 
+   For additional configuration examples including raster data,
    you can import the workspace *deegree-workspace-utah* through the workspace management (internet connection is required).
 
 View a map
@@ -64,18 +64,18 @@ View a map
 #. Click on the **+** on the right side to open a layer tree showing all available  layers. You can activate the a variety of layers served by the deegree WMS here.
 
 .. tip::
-   The map client is based on `OpenLayers <https://openlayers.org/>`_. 
+   The map client is based on `OpenLayers <https://openlayers.org/>`_.
    You can pan through the map holding the left mouse button and drag the map.
    Zooming is possible via mouse wheel or the navigation elements on the left side.
 
 What next?
 ==========
 
-This was just a short introduction to the features of deegree 3. 
+This was just a short introduction to the features of deegree 3.
 There is more information in the demo installations and on the deegree website.
 
   * deegree website - Available here: https://www.deegree.org
 
-  * deegree documentation - Available here: https://www.deegree.org/documentation/ 
-  
+  * deegree documentation - Available here: https://www.deegree.org/documentation/
+
   * deegree docker images - Available here: https://hub.docker.com/r/deegree/deegree3-docker/

--- a/doc/quickstart/eoxserver_quickstart.rst
+++ b/doc/quickstart/eoxserver_quickstart.rst
@@ -35,7 +35,7 @@ This Quick Start describes how to:
 Start EoxServer
 ===============
 
-Choose :menuselection:`Geospatial --> Web Services --> EOxServer`. This launches a
+Choose |menu_eoxserver|. This launches a
 browser showing the demonstration instance available at http://localhost/eoxserver/
 
 .. image:: /images/projects/eoxserver/eoxserver_start.png
@@ -54,7 +54,7 @@ demonstration instance is filled with ENVISAT MERIS scenes.
   :scale: 50 %
   :alt: Main view of the EOxServer Web Client
 
-The client consists of the map view and widgets that contain the main interactions. 
+The client consists of the map view and widgets that contain the main interactions.
 The main area is the map widget of the client with a set of datasets already displayed.
 On the bottom, you'll find the timeslider widget, that allows you to explore the
 contents in the temporal dimension.
@@ -133,7 +133,7 @@ clicking the "Collections" link and then the "MER_FRS_1P_RGB_reduced" link.
   :scale: 50 %
   :alt: EOxServer demonstration admin client Dataset Series
 
-You can preview the coverages by going back and clicking on the "Coverages" link. 
+You can preview the coverages by going back and clicking on the "Coverages" link.
 
 .. image:: /images/projects/eoxserver/eoxserver_adminclient4.png
   :scale: 50 %

--- a/doc/quickstart/geonode_quickstart.rst
+++ b/doc/quickstart/geonode_quickstart.rst
@@ -17,7 +17,7 @@
 
 Open Source Geospatial Content Management System
 
-GeoNode is a web-based application and platform for developing geospatial information systems (GIS) and for deploying spatial data infrastructures (SDI). 
+GeoNode is a web-based application and platform for developing geospatial information systems (GIS) and for deploying spatial data infrastructures (SDI).
 
 
 .. contents:: Contents
@@ -27,10 +27,9 @@ GeoNode is a web-based application and platform for developing geospatial inform
 Start GeoNode
 =============
 
-To start GeoNode on your OSGeoLive DVD you have to
-choose :menuselection:`Geospatial --> Browser Clients --> GeoNode --> Start GeoNode` and
-after a few moments the GeoNode webpage will automatically
-open at http://geonode. The page will look like the image below.
+To start GeoNode on your OSGeoLive DVD you have to choose |menu_geonode-Start|
+and after a few moments the GeoNode webpage will automatically open at
+http://geonode. The page will look like the image below.
 
     .. figure:: /images/projects/geonode/geonode_screenshot.png
       :scale: 70%
@@ -91,13 +90,13 @@ You should now be able to see all the files you want to upload.
    .. figure:: /images/projects/geonode/geonode_files_to_be_uploaded.png
      :scale: 70%
 
- .. Tip:: GeoNode has the ability to restrict who can view, edit, and manage layers. On the right side of the page you can see the *Permission* section, where you can limit the access on your layer. 
+ .. Tip:: GeoNode has the ability to restrict who can view, edit, and manage layers. On the right side of the page you can see the *Permission* section, where you can limit the access on your layer.
    Under *Who can view and download this data*, select *Any registered user*. This will ensure that anonymous view access is disabled.
    In the same area, under *Who can edit this data*, select your username. This will ensure that only you are able to edit the data in the layer.
 
     .. figure:: /images/projects/geonode/geonode_permission.png
       :scale: 70%
-    
+
 5. To upload data, click the *Upload* button at the bottom.
 
     .. figure:: /images/projects/geonode/geonode_upload_bar.png
@@ -138,7 +137,7 @@ The next step for you is to create a map and add the newly created layers to thi
 
    In this interface there is a toolbar, layer list, and map window. The map window contains the OpenStreetMap layer by default.
 
-3. Click on the *New Layers* button and select *Add Layers*. 
+3. Click on the *New Layers* button and select *Add Layers*.
 
    .. figure:: /images/projects/geonode/geonode_addlayerslink.png
      :scale: 70%
@@ -208,7 +207,7 @@ Your map can now be shared.
 What next?
 ==========
 
-Now you've gotten a quick insight in the possibilities of GeoNode. To learn more about GeoNode and its features, visit our webpage www.geonode.org. 
+Now you've gotten a quick insight in the possibilities of GeoNode. To learn more about GeoNode and its features, visit our webpage www.geonode.org.
 
 To install GeoNode on your own server, follow our `Quick Installation Guide <https://docs.geonode.org/en/master/start/index.html#quick-installation-guide>`_ .
 
@@ -218,5 +217,5 @@ If you need help or want to get some information about a specific topic please
 don't hasitate to ask us! You can do this through the #geonode IRC channel using
 https://webchat.freenode.net/, through the `GeoNode Gitter channel <https://gitter.im/GeoNode/general>`_
 or by asking your question in our `mailing list <https://lists.osgeo.org/cgi-bin/mailman/listinfo/geonode-users>`_ !
-    
-    
+
+

--- a/doc/quickstart/geopublisher_quickstart.rst
+++ b/doc/quickstart/geopublisher_quickstart.rst
@@ -38,18 +38,18 @@ Manuals
 Geopublisher (Create and export atlases)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * `Geopublisher manual, French, Created for version 1.2 <../../geopublishing/Geopublisher_v1.2_FR_Handbuch_090803.pdf>`_
-* `Geopublisher manual, German, Created for version 1.2 <../../geopublishing/Geopublisher_v1.2_DE_Handbuch_090801.pdf>`_    
+* `Geopublisher manual, German, Created for version 1.2 <../../geopublishing/Geopublisher_v1.2_DE_Handbuch_090801.pdf>`_
 
 AtlasStyler (Styling layers with SLD)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* `AtlasStyler manual, German, Created for version 1.2 <../../geopublishing/AtlasStyler_v1.2_DE_Handbuch_090601.pdf>`_  
+* `AtlasStyler manual, German, Created for version 1.2 <../../geopublishing/AtlasStyler_v1.2_DE_Handbuch_090601.pdf>`_
 
 AtlasViewer (How to use atlases created with Geopublisher)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * `AtlasViewer manual, French, Created for version 1.3 <../../geopublishing/AtlasViewer_v1.3_FR_Manual_090522.pdf>`_
-* `AtlasViewer manual, English, Created for version 1.3 <../../geopublishing/AtlasViewer_v1.3_EN_Manual_090522.pdf>`_ 
-* `AtlasViewer manual, German, Created for version 1.3 <../../geopublishing/AtlasViewer_v1.3_DE_Handbuch_090522.pdf>`_  
+* `AtlasViewer manual, English, Created for version 1.3 <../../geopublishing/AtlasViewer_v1.3_EN_Manual_090522.pdf>`_
+* `AtlasViewer manual, German, Created for version 1.3 <../../geopublishing/AtlasViewer_v1.3_DE_Handbuch_090522.pdf>`_
 
 
 Running
@@ -60,11 +60,11 @@ Getting Started
 
 Geopublisher is an end-user application, that allows you to compile and style your geodata and publish it to the world quickly. This DVD contains a small demo atlas, that you can use as a base before adding you own data.
 
-#) The OSGeoLive DVD uses the Lubuntu Operating system which has a temporary small problem with Java-based applications: As a solution please right-click on menu-bar (Where 'Applications' and 'Places' is listed) and select 'Customize Panel'. There check the 'Autohide' option. The menubar is now hidden unless your mouse reaches the top of the screen. 
+#) The OSGeoLive DVD uses the Lubuntu Operating system which has a temporary small problem with Java-based applications: As a solution please right-click on menu-bar (Where 'Applications' and 'Places' is listed) and select 'Customize Panel'. There check the 'Autohide' option. The menubar is now hidden unless your mouse reaches the top of the screen.
 
 #) Uncompress the demo atlas: Click on `this link <../../geopublishing/ChartDemoAtlas_WorkingCopy.zip>`_ and select 'Open with Archive Manager (default)'. This will open the ZIP file. Next select the third icon in the toolbar to extract and choose 'Desktop' as the target folder. Now you should have a folder 'ChartDemoAtlas' on your desktop. You can close the Archive Manager application.
 
-#) Now start the Geopublisher application. :menuselection:`Geospatial --> Desktop GIS --> Geopublisher`. Geopublisher starts and will ask you which atlas to open. Select 'atlas.gpa' from folder 'ChartDemoAtlas'. It now loads the atlas. You should see a triparted GUI with a map-pool, data-pool and menu area. This GUI allows you to create and organize multiple multi-language maps.
+#) Now start the Geopublisher application. |menu_geopublisher|. Geopublisher starts and will ask you which atlas to open. Select 'atlas.gpa' from folder 'ChartDemoAtlas'. It now loads the atlas. You should see a triparted GUI with a map-pool, data-pool and menu area. This GUI allows you to create and organize multiple multi-language maps.
 
 #) Add a Shapefile to the atlas: Select :menuselection:`File --> Import... --> Import files` and select '/home/user/data/natural_earth2/ne_10m_lakes.shp'. Geopublisher will ask you to describe that new layer with a title and a description. If that atlas would be configured to be multilingual, this information would be asked for every language. You will see the new layer appearing the DataPool section.
 
@@ -72,7 +72,7 @@ Geopublisher is an end-user application, that allows you to compile and style yo
 
 #) Export the atlas: :menuselection:`File --> Export` and follow the wizard: Export online and offline version of the atlas to a new directory 'Desktop/ChartAtlasExported'. When the export finished, click the "open folder" button. You see the exported and stand-alone versions of the atlas, that you were just editing.
 
-#) Try the exported atlas: Go into the `Desktop/ChartAtlasExported/DISK` folder and run `start.sh`. 
+#) Try the exported atlas: Go into the `Desktop/ChartAtlasExported/DISK` folder and run `start.sh`.
 
 #) Geopublisher has many more possibilities of course. Go to :menuselection:`Applications --> Education --> Geopublishing documentation` and look at all the documentation provided.
 

--- a/doc/quickstart/geoserver_quickstart.rst
+++ b/doc/quickstart/geoserver_quickstart.rst
@@ -130,9 +130,7 @@ that is included on OSGeoLive (:file:`/usr/local/share/data/natural_earth2/`).
    will notice that under *Native SRS* it says UNKNOWN you will need to fill in
    the next box (*declared SRS*) to make sure |GS| knows where the data is.
 
-#. You can type epsg:4326 in the box, or go to `http://prj2epsg.org/search
-   <http://prj2epsg.org/search>`_ and paste in the string you see if you click
-   on the link next to "UNKNOWN".
+#. You can type epsg:4326 in the box
 #. Click on :guilabel:`Compute from data` and :guilabel:`Compute from native
    bounds` to fill in the Bounding Boxes.
 #. Finally hit :guilabel:`save` and you have published your first layer.

--- a/doc/quickstart/gpsprune_quickstart.rst
+++ b/doc/quickstart/gpsprune_quickstart.rst
@@ -22,7 +22,7 @@ In this Quick Start, we will load and view a data file included on this live ima
 Start @NAME_gpsprune@
 ================================================================================
 
-From the Start menu, choose :menuselection:`Geospatial --> Navigation and Maps --> GpsPrune`.  This will then give you the empty window shown below.
+From the Start menu, choose |menu_gpsprune|.  This will then give you the empty window shown below.
 
 .. image:: /images/projects/gpsprune/gpsprune_emptywindow.png
    :scale: 55

--- a/doc/quickstart/grass_quickstart.rst
+++ b/doc/quickstart/grass_quickstart.rst
@@ -28,7 +28,7 @@ Start GRASS
 .. author's note: Update in osgeolive8.5: light NC dataset is included, tutorial
  rewritten
 
-#. Click on the GRASS link in the :menuselection:`Geospatial --> Desktop GIS` menu.
+#. Click on |menu_grass82|.
 #. From the "Welcome to GRASS GIS" window, select the "nc_basic_spm_grass7" dataset for the location, and "user1" for the mapset
 #. Click on :guilabel:`Start GRASS session`.
 

--- a/doc/quickstart/gvsig_quickstart.rst
+++ b/doc/quickstart/gvsig_quickstart.rst
@@ -44,7 +44,7 @@ gvSIG into the ideal tool for users working in the land realm.
 Start gvSIG and create a view
 =============================
 
-#. Select gvSIG from the application menu, :menuselection:`Geospatial --> Desktop GIS --> gvSIG`. The application usually takes about a minute to startup.
+#. Select gvSIG from the application menu, |menu_gvsig|. The application usually takes about a minute to startup.
 
 #. By default gvSIG opens with an empty project file with the 'View' document
    type selected. However, on OSGeoLive, gvSIG has been configured to
@@ -306,13 +306,13 @@ View the result
    :scale: 55
 
 
-Create a new map 
+Create a new map
 ================
 
 #. Select the *Map* document type in the **Project Manager**.
 #. Click on the :guilabel:`New` button to create a map.
-#. A new window is shown, where you can select the view to insert on the Map. 
-   Select the only view that you have and press *Accept*. 
+#. A new window is shown, where you can select the view to insert on the Map.
+   Select the only view that you have and press *Accept*.
 #. The map will appear with the view selected.
 
 Work with the map
@@ -355,7 +355,7 @@ Open the add-ons manager
 Find an add-on
 --------------
 
-#. At the add-ons manager we can find plugins and symbol libraries. 
+#. At the add-ons manager we can find plugins and symbol libraries.
 #. Type 'Forestry' in the *Fast filter* text box.
 #. Check the add-on called *Symbols: Forestry* (it's a symbol library).
 #. Click on *Next*.
@@ -370,7 +370,7 @@ Finish the installation
 #. Then click on *Next*.
 #. Finally click on *Finish*.
 
-Although the new message indicates that a restart is needed, for symbol libraries it's not necessary. We only have to restart when we install plugins. 
+Although the new message indicates that a restart is needed, for symbol libraries it's not necessary. We only have to restart when we install plugins.
 
 
 Add an OpenStreetMap layer

--- a/doc/quickstart/hyperv_quickstart.rst
+++ b/doc/quickstart/hyperv_quickstart.rst
@@ -7,18 +7,18 @@
 Running in a Hyper-V Virtual Machine
 ********************************************************************************
 
-This Quick Start describes how to run OSGeoLive using Hyper-V, Microsoft's virtualisation software. For other methods, follow links from the "See Also" section below. 
-Hyper-V is available on both Windows Server, and Windows 10 Professional - it is not part of Windows 10 Home. 
+This Quick Start describes how to run OSGeoLive using Hyper-V, Microsoft's virtualisation software. For other methods, follow links from the "See Also" section below.
+Hyper-V is available on both Windows Server, and Windows 10 Professional - it is not part of Windows 10 Home.
 
-The advantages of using a virtual machine are the same as those outlined at :doc:`virtualization_quickstart`. Unfortunately Virtual Box and Hyper-V 
-cannot be run simultaneously. This leaves 2 options - disabling the Hyper-V feature, or configuring a new Hyper-V machine to run OSGeoLive. 
-A free tool `hypervswitch <https://unclassified.software/en/apps/hypervswitch>`_ can be used to quickly enable and disable Hyper-V - however it still 
-requires a reboot each time the setting is changed. The rest of this page documents how to configure OSGeoLive to run on Hyper-V. 
+The advantages of using a virtual machine are the same as those outlined at :doc:`virtualization_quickstart`. Unfortunately Virtual Box and Hyper-V
+cannot be run simultaneously. This leaves 2 options - disabling the Hyper-V feature, or configuring a new Hyper-V machine to run OSGeoLive.
+A free tool `hypervswitch <https://unclassified.software/en/apps/hypervswitch>`_ can be used to quickly enable and disable Hyper-V - however it still
+requires a reboot each time the setting is changed. The rest of this page documents how to configure OSGeoLive to run on Hyper-V.
 
 System Requirements
 --------------------------------------------------------------------------------
 
-Hyper-V requirements can be found `here <https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/hyper-v-requirements>`_. 
+Hyper-V requirements can be found `here <https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v>`_.
 This link also provides information on checking if your machine is compatible using the ``systeminfo`` command. In summary the host machine
 needs to have the following hardware requirements:
 
@@ -32,92 +32,94 @@ Download the OSGeoLive VirtualBox virtual hard disk (vmdk) by following the link
 Once downloaded unzip the downloaded file (using `7zip <https://www.7-zip.org>`_ ).
 
 The virtual machine image format for Hyper-V differs from the VirtualBox download. The file therefore has to be converted from ``vmdk`` to
-``vhdx``. There are currently two conversion options available. 
+``vhdx``. There are currently two conversion options available.
 
 StarWind V2V Converter
 ++++++++++++++++++++++
 
 Use the `StarWind V2V Converter <https://www.starwindsoftware.com/starwind-v2v-converter>`_ program. This has a simple user interface allowing you to select the
-``osgeo-live-XX.X-vm.vmdk`` file and convert to a *Microsoft VHDX* image. 
+``osgeo-live-XX.X-vm.vmdk`` file and convert to a *Microsoft VHDX* image.
 
 Microsoft Virtual Machine Converter 3.0
 +++++++++++++++++++++++++++++++++++++++
 
 The second more complicated option is as follows.
 
-#. Download the `Microsoft Virtual Machine Converter 3.0 <https://www.microsoft.com/en-us/download/details.aspx?id=42497>`_ and install. 
+#. Download the `Microsoft Virtual Machine Converter 3.0
+   <https://techcommunity.microsoft.com/t5/system-center-blog/microsoft-virtual-machine-converter-3-0-is-now-available-for/ba-p/349874>`_
+   and install.
 #. Download the DS File Ops Kit and unzip.
 #. Open PowerShell (with administrator rights)
-#. Run the following command to get the disk descriptor from the OSGeoLive vmdk. This saves the disk description to the "descriptor1.txt" file. 
+#. Run the following command to get the disk descriptor from the OSGeoLive vmdk. This saves the disk description to the "descriptor1.txt" file.
 
-.. TODO link is broken #. Download the `DS File Ops Kit <http://members.ozemail.com.au/~nulifetv/freezip/freeware/dsfok.zip>`_ and unzip. 
+.. TODO link is broken #. Download the `DS File Ops Kit <http://members.ozemail.com.au/~nulifetv/freezip/freeware/dsfok.zip>`_ and unzip.
 
    .. code-block:: bat
-  
+
       cd D:\osgeo-live-11.0-vm
       D:\tools\dsfo.exe .\osgeo-live-11.0-vm.vmdk 512 1024 descriptor1.txt
-  
+
 #. Open this in a text editor (such as Notepad) and comment out the following lines using hashes (this metadata is VirtualBox specific and is not recognised by the converter):
 
-   .. code-block:: bat 
- 
+   .. code-block:: bat
+
       #ddb.uuid.image="0247ca9d-f9aa-4910-9e8c-1c14d83a7749"
       #ddb.uuid.parent="00000000-0000-0000-0000-000000000000"
       #ddb.uuid.modification="81a1d704-3e4a-443d-a5ca-2fd085ba086a"
       #ddb.uuid.parentmodification="00000000-0000-0000-0000-000000000000"
       #ddb.comment=""
-        
+
 #. Run the following command to insert the disk descriptor back into the ``vmdk`` file:
 
-   .. code-block:: bat 
-   
+   .. code-block:: bat
+
       D:\tools\dsfi.exe .\osgeo-live-11.0-vm.vmdk 512 1024 descriptor1.txt
 
    .. note::
-   
-      Failing to do the above steps will result in the error *"ConvertTo-MvmcVirtualHardDisk : The entry 0247ca9d-f9aa-4910-9e8c-1c14d83a7749 is not a supported 
+
+      Failing to do the above steps will result in the error *"ConvertTo-MvmcVirtualHardDisk : The entry 0247ca9d-f9aa-4910-9e8c-1c14d83a7749 is not a supported
       disk database entry for the descriptor."*
-    
+
 #. Finally run the conversion process:
 
    .. code-block:: bat
-   
+
       Import-Module "C:\Program Files\Microsoft Virtual Machine Converter\MvmcCmdlet.psd1"
       cd D:\osgeo-live-11.0-vm
-      ConvertTo-MvmcVirtualHardDisk -SourceLiteralPath .\osgeo-live-11.0-vm.vmdk -VhdFormat Vhdx 
+      ConvertTo-MvmcVirtualHardDisk -SourceLiteralPath .\osgeo-live-11.0-vm.vmdk -VhdFormat Vhdx
 
 
 How-To
 --------------------------------------------------------------------------------
 
-This guide assumes Hyper-V is already installed and enabled - if this is not the case the more typical approach using 
-Virtual Box outlined at :doc:`virtualization_quickstart` can be used. 
+This guide assumes Hyper-V is already installed and enabled - if this is not the case the more typical approach using
+Virtual Box outlined at :doc:`virtualization_quickstart` can be used.
 
 **Create a Virtual Machine**
 
-#. Start the Hyper-V Manager application and under Actions select New > Virtual Machine, and then Next. Then enter an appropriate 
-   name for the virtual machine. 
+#. Start the Hyper-V Manager application and under Actions select New > Virtual Machine, and then Next. Then enter an appropriate
+   name for the virtual machine.
 
    .. image:: /images/projects/osgeolive/osgeolive_hyperv_install1_start.png
 
-#. Select "Generation 1" from the Specify Generation options. 
+#. Select "Generation 1" from the Specify Generation options.
 
    .. image:: /images/projects/osgeolive/osgeolive_hyperv_install2_generation.png
 
-#. When assigning memory, you can select "Use Dynamic Memory for this virtual machine". 
-#. If you require the virtual machine to have Internet access you will need to set this up this up on the "Configure Networking" screen. 
-#. On the "Connect Virtual Hard Disk", select "Use an existing virtual hard disk" and select the ``.vhdx`` file you unzipped earlier. 
+#. When assigning memory, you can select "Use Dynamic Memory for this virtual machine".
+#. If you require the virtual machine to have Internet access you will need to set this up this up on the "Configure Networking" screen.
+#. On the "Connect Virtual Hard Disk", select "Use an existing virtual hard disk" and select the ``.vhdx`` file you unzipped earlier.
 
   .. image:: /images/projects/osgeolive/osgeolive_hyperv_install2_harddisk.png
 
 **Running the Virtual Machine**
 
 #. Select the virtual machine from the Virtual Machines list
-#. Right-click and select "Connect". You will be prompted to start the machine, and a new "Virtual Machine Connection" window will open. 
+#. Right-click and select "Connect". You will be prompted to start the machine, and a new "Virtual Machine Connection" window will open.
 
 See Also:
 --------------------------------------------------------------------------------
- * :doc:`virtualization_quickstart`. 
+ * :doc:`virtualization_quickstart`.
  * OSGeo wiki pages:
         `Other ways to create a Virtual Machine <https://wiki.osgeo.org/wiki/Live_GIS_Virtual_Machine>`_
 

--- a/doc/quickstart/istsos_quickstart.rst
+++ b/doc/quickstart/istsos_quickstart.rst
@@ -43,7 +43,7 @@ With istSOS you can organize your sensor data in different instances. Every inst
 
 The first steps into istSOS setup is to configure the default configuration options. These options will then be automatically used for your convenience by every new istSOS instance created.
 
-#. Click :menuselection:`Geospatial --> Webservices --> istSOS` to open the Web Admin interface. Alternatively, open a browser and go to `<http://localhost/istsos/admin>`_
+#. Click |menu_istsos| to open the Web Admin interface. Alternatively, open a browser and go to `<http://localhost/istsos/admin>`_
 
 #. Click the :guilabel:`Enter` button in the administration page.
 

--- a/doc/quickstart/kosmo_quickstart.rst
+++ b/doc/quickstart/kosmo_quickstart.rst
@@ -12,12 +12,12 @@
 @NAME_kosmo@ Quickstart
 ********************************************************************************
 
-Kosmo - Desktop is a user friendly, desktop GIS application which allows you to explore, edit 
+Kosmo - Desktop is a user friendly, desktop GIS application which allows you to explore, edit
 and analyse spatial data from a variety of databases, vector and raster formats.
 
 This Quick Start describes how to:
 
-* start the application    
+* start the application
 * load layers from files, databases and OGC services
 * navigate through the map
 * apply your styling to the loaded layers
@@ -30,7 +30,7 @@ Start Kosmo Desktop
 
 In order to start the application, follow the next steps:
 
-#. From the start menu, select :menuselection:`Geospatial --> Desktop GIS --> Kosmo`
+#. From the start menu, select |menu_kosmo|
 
 #. The application will take a few seconds to start (a splash screen is shown while loading)
 
@@ -55,11 +55,11 @@ In order to start the application, follow the next steps:
      :scale: 70 %
 
 #. Press the :guilabel:`Ok` button again to select the SRS loaded. The view will start with EPSG:4326 as the base projection
-    
-  
+
+
 .. tip::
   You can see which projection has been selected as base for a specific view in the view window title bar, right to the view name
-  
+
 
 Kosmo Desktop main window
 ================================================================================
@@ -77,13 +77,13 @@ The Kosmo Desktop main window has the following sections:
 
   Tree that contains the categories and layers that have been loaded in the current view.
 
-* Map  
+* Map
 
 * Status bar
 
   Shows the application warning messages to the user.
-  
-* Current cursor coordinates       
+
+* Current cursor coordinates
 
 
 
@@ -117,24 +117,24 @@ To start out, we're going to load some of the sample data included on the OSGeoL
 #. Press the :guilabel:`Ok` button to load the selected image file (**3**)
 
    .. image:: /images/projects/kosmo/kosmo_select_raster_file.png
-    :scale: 70 %   
+    :scale: 70 %
 
 #. In the layer tree, press the visibility checkbox to make the layer visible
 
 #. You can see that the layer drawing order is from bottom to top in the layer tree: modify the layer order by dragging them in order to show them properly
 
    .. image:: /images/projects/kosmo/kosmo_load_file_example.jpg
-    :scale: 70 %   
+    :scale: 70 %
 
 .. note::
   The OSGeoLive DVD contains some file data examples in the following directories:
-  
+
   * :file:`/home/user/data` (shapefiles and raster files)
   * :file:`/usr/local/share/OpenJUMP/sample_data` (shapefiles)
-      
-  You can try to load more examples from those directories. Remember to select the correct format from the *Format* combobox       
 
-.. tip:: 
+  You can try to load more examples from those directories. Remember to select the correct format from the *Format* combobox
+
+.. tip::
   It's possible to add all the images from a directory as an unique layer by selecting the parent directory in the *Load Dataset...* dialog: Kosmo Desktop will load them as a mosaic.
 
 
@@ -150,14 +150,14 @@ We're going to load a database table as an example:
 #. Fill the fields host, port, database name, user name and password with the values:
 
    * Host: localhost
-     
+
    * Port: 5432
-    
+
    * Database name: natural_earth2
-    
+
    * User name: user
-    
-   * Password: user        
+
+   * Password: user
 
 #. Press the :guilabel:`Connect` button to load the tables present at the *natural_earth2* database (**2**)
 
@@ -166,8 +166,8 @@ We're going to load a database table as an example:
 #. Press the :guilabel:`Ok` button to load the selected database table (**4**)
 
    .. image:: /images/projects/kosmo/kosmo_database_connection.png
-     :scale: 70 %   
-  
+     :scale: 70 %
+
 #. In the layer tree, press the visibility checkbox to make the layer visible
 
    .. image:: /images/projects/kosmo/kosmo_load_database_example.jpg
@@ -184,24 +184,24 @@ OGC services
 #. In the *Select SDI service type* panel, select the option *WMS Service* (**1**) and press the :guilabel:`Next` button (**2**)
 
    .. image:: /images/projects/kosmo/kosmo_wms_1.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. In the *Select Uniform Resource Locator (URL)*, type the URL http://localhost:8082/geoserver/ows? in the corresponding text field (**1**) and press the :guilabel:`Connect` button (**2**)
 
 #. If the connection is successful, press the :guilabel:`Next` button to go to the next panel (**3**)
 
    .. image:: /images/projects/kosmo/kosmo_wms_2.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. Select the layer `North America Sample Imagery` (**1**) and press the :guilabel:`>` button (**2**) to move it to the right list. Press :guilabel:`Next` button. (**3**)
 
    .. image:: /images/projects/kosmo/kosmo_wms_3.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. Leave the default options loaded and press the :guilabel:`Finish` button (**1**) to start the layer loading
 
    .. image:: /images/projects/kosmo/kosmo_wms_4.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. In the layer tree, press the visibility checkbox to make the layer visible
 
@@ -210,11 +210,11 @@ OGC services
 #. Reorder the layer tree by dragging the new layer and put it over the *HYP_50M_SR_W* raster layer
 
    .. image:: /images/projects/kosmo/kosmo_load_wms_results.jpg
-     :scale: 70 %   
+     :scale: 70 %
 
 
 .. note::
-  Kosmo Desktop contains a set of lists of WMS servers by default, divided into locations (most of them are from Spain). 
+  Kosmo Desktop contains a set of lists of WMS servers by default, divided into locations (most of them are from Spain).
   If you're connected to internet, you can use them as described in the example with the local server.
 
 
@@ -227,65 +227,65 @@ You can control where in the world is the map using the navigation tools present
 1. |ZOOM| Zoom In/Out
 
   .. |ZOOM| image:: /images/projects/kosmo/kosmo_zoom.png
-  
+
   * It's the tool selected by default when you start your session
   * Use the mouse left button to zoom in a fixed ammount at the clicked map point
   * Use the mouse right button to zoom out a fixed amount at the clicked map point
   * Press the mouse left button, move the mouse, draw a rectangle and release the button if you want to zoom to that rectangle
-  
+
 #. |PAN| Pan
-  
+
   .. |PAN| image:: /images/projects/kosmo/kosmo_pan.png
 
   * Allows to move around the world without changing the scale
   * Press the mouse left button, move the mouse and release it in order to move the map to the desired location
-      
+
 #. |ZOOM_PREV| Zoom Previous
 
   .. |ZOOM_PREV| image:: /images/projects/kosmo/kosmo_zoom_prev.png
-  
+
   * Allows to zoom to the previous viewing envelope from the zoom history (if available)
-  
+
 #. |ZOOM_NEXT| Zoom Next
 
   .. |ZOOM_NEXT| image:: /images/projects/kosmo/kosmo_zoom_next.png
-  
+
   * Allows to zoom to the next viewing envelope from the zoom history (if available)
-    
+
 #. |ZOOM_FULL_EXTENT| Zoom To Full Extent
 
   .. |ZOOM_FULL_EXTENT| image:: /images/projects/kosmo/kosmo_zoom_to_full_extent.png
-  
+
   * Allows to change the current map envelope to include all the visible layers
-  
+
 #. |ZOOM_TO_LAYER| Zoom To Layer
 
   .. |ZOOM_TO_LAYER| image:: /images/projects/kosmo/kosmo_zoom_to_layer.png
-  
+
   * Allows to change the current map envelope to adjust to the selected layer
-    
+
 #. |ZOOM_TO_SELECTED_ITEMS| Zoom To Selected Items
 
   .. |ZOOM_TO_SELECTED_ITEMS| image:: /images/projects/kosmo/kosmo_zoom_to_selected_items.png
-  
+
   * Allows to change the current map envelope to adjust to the selected features
-    
+
 #. |PAN_TO_CLICK| Pan To Click
 
   .. |PAN_TO_CLICK| image:: /images/projects/kosmo/kosmo_pan_to_click.png
-  
+
   * Centers the map in the clicked map point, without changing the current scale
-  
+
 #. |COORDINATE_LOCALIZATION| Coordinate Localization
 
   .. |COORDINATE_LOCALIZATION| image:: /images/projects/kosmo/kosmo_coordinate_localization.png
-  
+
   * Centers the map in the given X - Y coordinates
 
 Apart from those tools, it's also available the possibility to zoom in/out by using the mouse wheel.
 
 .. note::
-  If any tool/menu option is disabled, you can place the cursor over the button/option to see a tooltip where the reason is shown 
+  If any tool/menu option is disabled, you can place the cursor over the button/option to see a tooltip where the reason is shown
 
 
 
@@ -307,14 +307,14 @@ In this section we're going to style a layer by range using the country populati
 #. Press the :guilabel:`Ok` button to apply the changes (**6**)
 
    .. image:: /images/projects/kosmo/kosmo_basic_style_classification.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. The layer will change its style to reflect the changes:
 
    .. image:: /images/projects/kosmo/kosmo_styled_layer_by_range.jpg
      :scale: 70 %
-     
-     
+
+
 
 Advanced Styling
 ================================================================================
@@ -325,20 +325,20 @@ In this section we're going to style a layer with some rules and filters, based 
 
 #. Right click on it and select the option :menuselection:`Simbology > Advanced Style Editor...`
 
-#. Select the feature type style `ne_10m_populated_places` (**1**) and press the :guilabel:`+` button (**2**) to add a new rule to it 
+#. Select the feature type style `ne_10m_populated_places` (**1**) and press the :guilabel:`+` button (**2**) to add a new rule to it
 
    .. image:: /images/projects/kosmo/kosmo_advanced_style_feature_type.png
-     :scale: 70 %   
- 
+     :scale: 70 %
+
 #. Select `Point symbolizer` as symbolizer type (**1**) and press the :guilabel:`Ok` button (**2**)
 
    .. image:: /images/projects/kosmo/kosmo_advanced_style_symbolizer.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. Select the new rule in the tree (**1**) and edit its properties: set **capital_rule** as `Name` (**2**), **Capitals** as `Title` (**3**),activate its filter (**4**) and edit it (**5**)
 
    .. image:: /images/projects/kosmo/kosmo_advanced_style_capital_rule.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. Select **featurecla** as `Field` (**1**), **Equal to (=)** as `Operator` (**2**) and press the :guilabel:`...` button (**3**) to select an attribute value
 
@@ -348,22 +348,22 @@ In this section we're going to style a layer with some rules and filters, based 
 #. Select the **Admin-0 capital** value (**1**) and press the :guilabel:`Ok` button (**2**)
 
    .. image:: /images/projects/kosmo/kosmo_advanced_style_attr_value.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. Press the :guilabel:`Add` button (**1**) to add the condition to the filter and the :guilabel:`Ok` button (**2**) to set the filter to the rule
 
    .. image:: /images/projects/kosmo/kosmo_advanced_style_filter_2.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. Select the capital rule point symbolizer in the tree (**1**) and edit its properties: set its `Size` to **8** (**2**), its `Well Known Mark` type as **circle** (**3**) and `Color` to light green (**4**)
 
    .. image:: /images/projects/kosmo/kosmo_advanced_style_capital_rule_symbolizer.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. Select the other rule in the tree (**1**) and edit its properties: set **others_rule** as `Name` (**2**), **Others** as `Title` (**3**), mark the `Else filter` checkbox (**4**) and set its maximum scale to **25,000,000** (**5**) (it's necessary to press :guilabel:`ENTER` key after setting the value manually to set it)
 
    .. image:: /images/projects/kosmo/kosmo_advanced_style_others_rule.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. Press the :guilabel:`Ok` button to apply the changes
 
@@ -371,7 +371,7 @@ In this section we're going to style a layer with some rules and filters, based 
 
    .. image:: /images/projects/kosmo/kosmo_styled_layer_by_filter.jpg
      :scale: 70 %
-          
+
 #. If you make enough zoom in to reach the given scale, both rules would be rendered:
 
    .. image:: /images/projects/kosmo/kosmo_styled_layer_by_filter_2.jpg
@@ -391,14 +391,14 @@ In this section we're going to activate the Sextante toolbox extension:
 #. Mark the Sextante extension checkbox (**1**) and press the :guilabel:`Ok` button (**2**)
 
    .. image:: /images/projects/kosmo/kosmo_extension_manager.png
-     :scale: 70 %   
+     :scale: 70 %
 
 #. A new Sextante button will be available at the right of the main toolbar
 
    .. image:: /images/projects/kosmo/kosmo_sextante_extension.png
-     :scale: 70 %   
+     :scale: 70 %
 
-.. tip:: 
+.. tip::
   If the `Mark as default` option is selected, the extension would be loaded automatically on next application startup
 
 

--- a/doc/quickstart/mapbender_quickstart.rst
+++ b/doc/quickstart/mapbender_quickstart.rst
@@ -39,7 +39,7 @@ This is how a Mapbender application can look like:
 Start Mapbender
 ================================================================================
 
-#. Choose  :menuselection:`Geospatial --> Browser Clients --> Mapbender` from the start menu or visit http://localhost/mapbender/app.php. The application will take a few moments to start up
+#. Choose  |menu_mapbender| from the start menu or visit http://localhost/mapbender/app.php. The application will take a few moments to start up
 
    If you have any difficulties running Mapbender, please check whether your Apache web server and your PostgreSQL database are running. Or if you use SQLite as database whether you have write access to the file.
 
@@ -73,10 +73,10 @@ Create a new application by providing basic information about your application. 
 
 #. Choose the button **Create** to create the application
 
-.. tip:: You can easily create an application by copying an existing application using the **Duplicate Application** button. 
+.. tip:: You can easily create an application by copying an existing application using the **Duplicate Application** button.
 
 
-Your application is set up. Next you need a WMS to be displayed in your application. 
+Your application is set up. Next you need a WMS to be displayed in your application.
 
   .. image:: /images/projects/mapbender/mapbender3_create_application.png
      :scale: 70 %
@@ -92,7 +92,7 @@ A WMS returns an XML-file when the getCapabilities document is requested. This i
 
 #. Choose menu item :menuselection:`Services --> Add Service` or use the +-Button.
 
-#. Link to the WMS getCapabilities URL in the text field :menuselection:`Serviceurl`. 
+#. Link to the WMS getCapabilities URL in the text field :menuselection:`Serviceurl`.
    Here is a example WMS: WhereGroup OSM WMS https://osm-demo.wheregroup.com/service?SERVICE=WMS&VERSION=1.3.0&REQUEST=getCapabilities
 
 #. Enter username and password if your service needs authentication.

--- a/doc/quickstart/mapnik_quickstart.rst
+++ b/doc/quickstart/mapnik_quickstart.rst
@@ -31,7 +31,7 @@ Mapnik and its python bindings are installed and ready to be used for scripting 
 Creating maps in python is easy with Mapnik. Open a terminal window and type `python3` on the command line to enter a python interpreter. Then try this::
 
 ::
-  
+
     import mapnik, os
     m = mapnik.Map(600,400)
     style = '/usr/local/share/mapnik/world_population.xml'
@@ -42,7 +42,7 @@ Creating maps in python is easy with Mapnik. Open a terminal window and type `py
 
 
 .. note::
-    
+
       The above code depends on having an XML stylesheet that Mapnik can read (world_population.xml), defining the layers
       to read data from and the styles to apply to those layers.
 
@@ -52,9 +52,9 @@ Mapnik & MapProxy
 
 A basic demo application is available which demonstrates using Mapnik with MapProxy
 
-The demo uses the world_population.xml from the Mapnik demo. 
+The demo uses the world_population.xml from the Mapnik demo.
 
-#. Click :menuselection:`Geospatial --> Web Services --> MapProxy --> Start MapProxy`. The server starts in a terminal window (which stays open and outputs basic debugging information).
+#. Click |menu_mapnik|. The server starts in a terminal window (which stays open and outputs basic debugging information).
 
 #. Open the MapProxy demo application http://0.0.0.0:8011/demo/
 
@@ -62,7 +62,7 @@ The demo uses the world_population.xml from the Mapnik demo.
 
 
 #. You can use the MapProxy WMS in other applications for example in QGIS or in Mapbender (http://localhost/mapbender/application/mapbender_user).
- 
+
 
 #. Observe the output in the server terminal window.
 

--- a/doc/quickstart/mapproxy_quickstart.rst
+++ b/doc/quickstart/mapproxy_quickstart.rst
@@ -32,7 +32,7 @@ Start the service and view the demo
 
 MapProxy has flexible deployment options and you can integrate it in Apache for example. But you can also start MapProxy as a standalone service, which is the best option to get started.
 
-#. To start MapProxy as a standalone service click on :menuselection:`Geospatial --> Web Services --> MapProxy --> Start MapProxy`.
+#. To start MapProxy as a standalone service click on |menu_mapproxy-Start|.
 
 #. Open Firefox and navigate to `<http://localhost:8011/demo>`_
 

--- a/doc/quickstart/mapserver_quickstart.rst
+++ b/doc/quickstart/mapserver_quickstart.rst
@@ -20,9 +20,9 @@
 @NAME_mapserver@ Quickstart
 ================================================================================
 
-MapServer is an `Open Source <https://opensource.org/>`_ server based 
-application that allows you to publish geographic map images and vector data 
-through the internet using |OGCS| 
+MapServer is an `Open Source <https://opensource.org/>`_ server based
+application that allows you to publish geographic map images and vector data
+through the internet using |OGCS|
 such as |WMS|, |WFS| and |WCS|.
 
 .. contents:: Contents
@@ -33,43 +33,43 @@ such as |WMS|, |WFS| and |WCS|.
 Configure MapServer using the Mapfile configuration file
 ========================================================
 
-.. note:: 
+.. note::
 
-  **What will I learn ?** In this section, you will learn what a 
-  Mapfile is and how to configure it to allow MapServer to serve a shapefile 
+  **What will I learn ?** In this section, you will learn what a
+  Mapfile is and how to configure it to allow MapServer to serve a shapefile
   as images using WMS requests.
 
 What is a Mapfile ?
 -------------------
 
-The `Mapfile <https://mapserver.org/mapfile/index.html>`_ is the 
-configuration file that MapServer uses to render geospatial data as images 
-or vector data. Its main purpose is to define the layers it can draw, how to 
+The `Mapfile <https://mapserver.org/mapfile/index.html>`_ is the
+configuration file that MapServer uses to render geospatial data as images
+or vector data. Its main purpose is to define the layers it can draw, how to
 read necessary data, and how to render it (e.g. color, symbol, label, etc...).
 
 Creating my first Mapfile
 -------------------------
 
-#. Open any text editor (e.g. :menuselection:`Applications --> Accessories --> 
+#. Open any text editor (e.g. :menuselection:`Applications --> Accessories -->
    FeatherPad`).
-#. Create the file "mapserver_quickstart.map" in your home directory: 
+#. Create the file "mapserver_quickstart.map" in your home directory:
    :file:`/home/user/mapserver_quickstart.map`
 
    Put the following content in it::
-   
+
      MAP
        NAME "MAPSERVER_QUICKSTART"
        EXTENT -137 29 -53 88
        UNITS DD
        SHAPEPATH "/home/user/data/natural_earth2/"
        SIZE 800 600
-   
+
        IMAGETYPE PNG24
-     
+
        PROJECTION
-         "init=epsg:4326" 
+         "init=epsg:4326"
        END
-   
+
        WEB
          METADATA
            ows_title "MapServer Quickstart"
@@ -77,57 +77,57 @@ Creating my first Mapfile
            ows_srs "EPSG:4326 EPSG:25832 EPSG:25833"
          END
        END
-   
+
        LAYER
          NAME "Countries"
          STATUS ON
          TYPE POLYGON
          DATA "ne_10m_admin_0_countries"
-         CLASS 
+         CLASS
            STYLE
              COLOR 246 241 223
              OUTLINECOLOR 0 0 0
            END
-         END 
+         END
        END
-   
+
      END
 
    .. note::
-   
-     The example uses the natural earth dataset, which is already on OSGeoLive at :file:`~/data/natural_earth2` (a short cut to 
+
+     The example uses the natural earth dataset, which is already on OSGeoLive at :file:`~/data/natural_earth2` (a short cut to
      :file:`/usr/local/share/data/natural_earth2`).
 
-Each object in a Mapfile starts with its name (for example **MAP**) and ends 
-with an **END**.  A Mapfile always starts with the **MAP** object and should 
-contain a list of **LAYER** objects the Mapfile can read and draw. In our 
+Each object in a Mapfile starts with its name (for example **MAP**) and ends
+with an **END**.  A Mapfile always starts with the **MAP** object and should
+contain a list of **LAYER** objects the Mapfile can read and draw. In our
 Mapfile, we currently have only one layer defined.
 
-Let's take a look at some of the objects (and properties) defined in our 
-Mapfile: 
+Let's take a look at some of the objects (and properties) defined in our
+Mapfile:
 
  * EXTENT: sets the default geospatial bounding box for this configuration.
- * LAYER: defines access and display properties for a spatial dataset.  We'll 
+ * LAYER: defines access and display properties for a spatial dataset.  We'll
    add another layer later.
- * SHAPEPATH: sets a base path for file-based data (e.g. shapefiles or tiff 
-   images). 
+ * SHAPEPATH: sets a base path for file-based data (e.g. shapefiles or tiff
+   images).
 
-If we look closer at the **LAYER** in our Mapfile, we'll see that it 
+If we look closer at the **LAYER** in our Mapfile, we'll see that it
 contains a bunch of properties and objects too. Among them are:
 
- * STATUS: defines whether the layer can be drawn (*ON*), can't be drawn 
+ * STATUS: defines whether the layer can be drawn (*ON*), can't be drawn
    (*OFF*) or is always drawn (*DEFAULT*).
- * TYPE: the geometry type that MapServer should use when rendering the data 
+ * TYPE: the geometry type that MapServer should use when rendering the data
    as an image. In our Mapfile, the data will be drawn as *polygons*.
- * DATA: the name of the spatial data file this layer uses, in this case a 
+ * DATA: the name of the spatial data file this layer uses, in this case a
    shapefile.
- * CLASS: determines how to draw a layer (styling). We'll cover this object in 
+ * CLASS: determines how to draw a layer (styling). We'll cover this object in
    more detail later.
 
 .. note::
 
-  A complete list of the available objects and properties a Mapfile can have 
-  can be found in the `MapServer documentation page 
+  A complete list of the available objects and properties a Mapfile can have
+  can be found in the `MapServer documentation page
   <https://mapserver.org/mapfile/index.html>`_.
 
 
@@ -137,7 +137,7 @@ Render a map image with MapServer using a WMS **GetMap** request
 
 .. note::
 
-  **What will I learn ?** You will learn how to use to render an image with 
+  **What will I learn ?** You will learn how to use to render an image with
   layers from a Mapfile with MapServer using an OGC WMS request.
 
 Open a web browser and enter the following URL::
@@ -145,12 +145,12 @@ Open a web browser and enter the following URL::
   http://localhost/cgi-bin/mapserv?map=/home/user/mapserver_quickstart.map&SERVICE=WMS&REQUEST=Getmap&VERSION=1.1.1&LAYERS=Countries&SRS=EPSG:4326&BBOX=-137,29,-53,88&FORMAT=PNG&WIDTH=800&HEIGHT=600
 
 What does the above mean?  If we put it in simple words, it's a |WMS|
-**GetMap** 
-request that tells MapServer to "*use the following Mapfile to render the 
-specified layers as a png image based on some user-supplied parameters such 
-as image size, geographical extent, projection, etc.*".  All layers 
-specified in the "*&LAYERS=...*" property having *STATUS ON* in the Mapfile 
-will be rendered in addition to all layers with *STATUS DEFAULT*. The 
+**GetMap**
+request that tells MapServer to "*use the following Mapfile to render the
+specified layers as a png image based on some user-supplied parameters such
+as image size, geographical extent, projection, etc.*".  All layers
+specified in the "*&LAYERS=...*" property having *STATUS ON* in the Mapfile
+will be rendered in addition to all layers with *STATUS DEFAULT*. The
 result looks like the following:
 
   .. image:: /images/projects/mapserver/mapserver_map.png
@@ -158,7 +158,7 @@ result looks like the following:
 
 .. note::
 
-  All parameters of the request are WMS-specific, except 
+  All parameters of the request are WMS-specific, except
   "*?map=/home/user/mapserver_quickstart.map*", which is MapServer-specific.
 
 
@@ -166,16 +166,16 @@ result looks like the following:
 Render a map image with MapServer using the command line
 ========================================================
 
-Although MapServer is geared towards web applications, it can also produce 
-images on the command line. This can be useful if you are looking for 
+Although MapServer is geared towards web applications, it can also produce
+images on the command line. This can be useful if you are looking for
 repetitive mapping, or while debugging.
 
-Open a terminal (:menuselection:`Applications --> System Tools --> Terminal 
+Open a terminal (:menuselection:`Applications --> System Tools --> Terminal
 Emulator`) and type::
 
   shp2img -m mapserver_quickstart.map -o mymap.png
 
-If this command runs successfully, you are able to see your rendered map at 
+If this command runs successfully, you are able to see your rendered map at
 file:///home/user/mymap.png.
 
 
@@ -185,10 +185,10 @@ Add a new layer to the Mapfile to serve a local Shapefile
 
 .. note::
 
-  **What will I learn ?** You will learn how to add a new layer object 
+  **What will I learn ?** You will learn how to add a new layer object
   definition to your Mapfile.
 
-We will now add a new layer to our Mapfile. Before the last *END* statement 
+We will now add a new layer to our Mapfile. Before the last *END* statement
 in the Mapfile, add the following layer configuration::
 
   LAYER
@@ -196,24 +196,24 @@ in the Mapfile, add the following layer configuration::
     STATUS ON
     TYPE POLYGON
     DATA "ne_10m_lakes"
-    CLASS 
+    CLASS
       STYLE
         COLOR 153 179 204
       END
-    END 
+    END
   END
 
-Now we have 2 layer definitions in our Mapfile. Note that the new one we 
-just added has the "STATUS" property set to "ON". That means that unless we 
+Now we have 2 layer definitions in our Mapfile. Note that the new one we
+just added has the "STATUS" property set to "ON". That means that unless we
 specifically request it, it won't be rendered.
 
-Let's take our previous WMS **GetMap** request and add our new "Lakes" layer 
-to the image rendered. We simply need to add the new layer name to the 
+Let's take our previous WMS **GetMap** request and add our new "Lakes" layer
+to the image rendered. We simply need to add the new layer name to the
 "LAYERS" property list::
 
   http://localhost/cgi-bin/mapserv?map=/home/user/mapserver_quickstart.map&SERVICE=WMS&REQUEST=Getmap&VERSION=1.1.1&LAYERS=Countries,Lakes&SRS=EPSG:4326&BBOX=-137,29,-53,88&FORMAT=PNG&WIDTH=800&HEIGHT=600
 
-The image rendered by MapServer looks like our previous map, but with the 
+The image rendered by MapServer looks like our previous map, but with the
 addition of the lakes from our new layer:
 
   .. image:: /images/projects/mapserver/mapserver_lakes.png
@@ -226,20 +226,20 @@ Style a layer using Mapfile configurations
 
 .. note::
 
-  **What will I learn ?** You will see an example of styling elements inside 
+  **What will I learn ?** You will see an example of styling elements inside
   a layer depending on some of its data properties.
 
-In a Mapfile, a LAYER object can contain an infinite number of CLASS 
-objects. These are used to style the elements contained in the spatial data 
-file (DATA). For example, if we look closer at our "ne_10m_lakes" data file 
-using a tool such as `ogrinfo <https://gdal.org/ogrinfo.html>`_, we'll 
-see the geometry and attribute definitions it contains. These attribute 
-values can be used as a way to draw the elements inside a dataset 
+In a Mapfile, a LAYER object can contain an infinite number of CLASS
+objects. These are used to style the elements contained in the spatial data
+file (DATA). For example, if we look closer at our "ne_10m_lakes" data file
+using a tool such as `ogrinfo <https://gdal.org/ogrinfo.html>`_, we'll
+see the geometry and attribute definitions it contains. These attribute
+values can be used as a way to draw the elements inside a dataset
 differently using multiple CLASS objects.
 
-In our "ne_10m_lakes" dataset, we have a *ScaleRank* attribute, which seems 
-to be related to the size of the lakes. We can use this as a way to render 
-the lakes differently. In the LAYER object, we'll add another CLASS object 
+In our "ne_10m_lakes" dataset, we have a *ScaleRank* attribute, which seems
+to be related to the size of the lakes. We can use this as a way to render
+the lakes differently. In the LAYER object, we'll add another CLASS object
 just before our current one::
 
   LAYER
@@ -248,13 +248,13 @@ just before our current one::
     TYPE POLYGON
     DATA "ne_10m_lakes"
     CLASSITEM "ScaleRank"
-    CLASS 
+    CLASS
       EXPRESSION /0|1/
       STYLE
         COLOR 153 179 204
         OUTLINECOLOR 0 0 0
       END
-    END 
+    END
     CLASS
       STYLE
         COLOR 153 179 204
@@ -262,18 +262,18 @@ just before our current one::
     END
   END
 
-What does our new CLASS object do? It basically tells MapServer to draw the 
-elements having the "ScaleRank" property equal to "0" or "1" with a black 
-outline. Class objects are always read from the top to the bottom for each 
-feature to be drawn. When a feature matches the "EXPRESSION" specified in a 
-class, that class is going to render the feature. If the feature does not 
-match a class the next class is checked. If a feature does not match any 
-class then it is not rendered at all but if the last class in a layer 
-contains no EXPRESSION then that class acts as a default. The LAYER 
-"CLASSITEM" property tells MapServer which attribute to use when evaluating 
+What does our new CLASS object do? It basically tells MapServer to draw the
+elements having the "ScaleRank" property equal to "0" or "1" with a black
+outline. Class objects are always read from the top to the bottom for each
+feature to be drawn. When a feature matches the "EXPRESSION" specified in a
+class, that class is going to render the feature. If the feature does not
+match a class the next class is checked. If a feature does not match any
+class then it is not rendered at all but if the last class in a layer
+contains no EXPRESSION then that class acts as a default. The LAYER
+"CLASSITEM" property tells MapServer which attribute to use when evaluating
 EXPRESSIONs defined in the CLASS objects.
 
-The result of this new addition should make the big lakes in our map image 
+The result of this new addition should make the big lakes in our map image
 rendered with a black outline:
 
   .. image:: /images/projects/mapserver/mapserver_lakes_scalerank.png
@@ -281,7 +281,7 @@ rendered with a black outline:
 
 .. note::
 
-  Learn more about `EXPRESSIONS 
+  Learn more about `EXPRESSIONS
   <https://mapserver.org/mapfile/expressions.html>`_ in MapServer.
 
 
@@ -293,13 +293,15 @@ MapServer supports different OGC Standards like OGC WMS, WFS or WCS. With OGC WM
 Using QGIS Desktop to load your OGC WMS
 ---------------------------------------
 
-#. Start QGIS via :menuselection:`Geospatial --> Desktop GIS --> QGIS Desktop`. Go to :menuselection:`Layer --> Add Layer --> Add WMS/WMTS Layer`.
+#. Start QGIS via |menu_qgis|
+
+#. Go to :menuselection:`Layer --> Add Layer --> Add WMS/WMTS Layer`.
 
 #. Click button **New** and add a name and your Service URL
 
 #. Save your settings:
 
-   http://localhost/cgi-bin/mapserv?map=/home/user/mapserver_quickstart.map&SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0  
+   http://localhost/cgi-bin/mapserv?map=/home/user/mapserver_quickstart.map&SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0
 
 Then you can connect to your service and add one or more layers of the service to your QGIS project. If you choose the layer with the ID 0 you can load the whole service with all layers at once.
 
@@ -310,18 +312,18 @@ Then you can connect to your service and add one or more layers of the service t
 What Next?
 ==========
 
-This is a simple example, but you can do much, much more. The MapServer 
-project website contains many resources to help you get started. Here's a 
+This is a simple example, but you can do much, much more. The MapServer
+project website contains many resources to help you get started. Here's a
 few resources to check out next:
 
-* Read the `Introduction to MapServer 
+* Read the `Introduction to MapServer
   <https://mapserver.org/introduction.html#introduction>`_.
-* Have a look at the `MapServer Tutorial 
-  <https://www.mapserver.org/tutorial/index.html>`_ which contains more Mapfile 
+* Have a look at the `MapServer Tutorial
+  <https://www.mapserver.org/tutorial/index.html>`_ which contains more Mapfile
   examples.
-* Check the `OGC Support and Configuration 
-  <https://www.mapserver.org/ogc/index.html>`_ to learn more about OGC 
+* Check the `OGC Support and Configuration
+  <https://www.mapserver.org/ogc/index.html>`_ to learn more about OGC
   standards in MapServer (WMS, WFS, SLD, WFS Filter Encoding, WCS, SOS, etc.).
-* Ready to use MapServer? Then join the community on the `Mailing Lists 
-  <https://www.mapserver.org/community/lists.html>`_ to exchange ideas, discuss 
+* Ready to use MapServer? Then join the community on the `Mailing Lists
+  <https://www.mapserver.org/community/lists.html>`_ to exchange ideas, discuss
   potential software improvements and ask questions.

--- a/doc/quickstart/ncWMS_quickstart.rst
+++ b/doc/quickstart/ncWMS_quickstart.rst
@@ -23,7 +23,7 @@ ncWMS is a Web Map Service which allows the fast visualisation of data from NetC
 Start ncWMS and understand the workspace
 ========================================
 
-Select :menuselection:`Geospatial --> Web Services --> ncWMS --> Start ncWMS`.
+Select |menu_ncWMS-Start|.
 
 After a few moments the application will start up and open a web browser at http://localhost:8080/ncWMS2/Godiva3.html
 
@@ -31,8 +31,8 @@ After a few moments the application will start up and open a web browser at http
     :scale: 55 %
 
 
-* Use the left-hand menu to choose a dataset to view.  
-* Clicking a dataset (or the + icon to the left of it) will expand the dataset to show the available variables to plot.  
+* Use the left-hand menu to choose a dataset to view.
+* Clicking a dataset (or the + icon to the left of it) will expand the dataset to show the available variables to plot.
 * Choose a variable by clicking on it. The data displays on the interactive map after a short delay (a progress bar may display showing the progress of loading image tiles from the WMS servers).
 
 Navigating the map
@@ -48,7 +48,7 @@ If the variable you are viewing has a vertical dimension you will be able to sel
 Selecting the timestep
 ----------------------
 
-If the displayed variable has a time dimension a date control will appear above the map. Click on this control to select the date you want to focus on. If there are several timesteps available for this day, use the drop-down box above the map to select the time. 
+If the displayed variable has a time dimension a date control will appear above the map. Click on this control to select the date you want to focus on. If there are several timesteps available for this day, use the drop-down box above the map to select the time.
 
 Finding the data value at a point
 ---------------------------------
@@ -98,10 +98,10 @@ Creating a timeseries plot uses a similar wizard to that used to create animatio
 Vertical sections and transects along arbitrary paths
 -----------------------------------------------------
 
-#. At the top of the map, click the icon that looks like a line joining four points. 
-#. Click on the map to start drawing a line. 
-#. Add "waypoints" along this line by single-clicking at each point. 
-#. Double-click to finish the line. 
+#. At the top of the map, click the icon that looks like a line joining four points.
+#. Click on the map to start drawing a line.
+#. Add "waypoints" along this line by single-clicking at each point.
+#. Double-click to finish the line.
    A new browser window opens showing the variation of the viewed variable along the line (i.e. a transect plot). If the variable has a vertical dimension, a vertical section plot will display under the transect plot.
 
 
@@ -121,11 +121,11 @@ The map projection is changed by selecting a new background map as above. If the
 Saving and emailing the view
 ============================
 
-You may want to save the current view to return to it later or share it with a colleague. The "Permalink" under the bottom right-hand corner of the map links to a complete URL that recreates the current view. 
+You may want to save the current view to return to it later or share it with a colleague. The "Permalink" under the bottom right-hand corner of the map links to a complete URL that recreates the current view.
 
-* Left-click on the permalink to bring up a new window with an identical view. 
+* Left-click on the permalink to bring up a new window with an identical view.
 
-* Right-click on the permalink and select "Copy link location" or the equivalent for your web browser. You can then paste the link into a report, your notes or an email. 
+* Right-click on the permalink and select "Copy link location" or the equivalent for your web browser. You can then paste the link into a report, your notes or an email.
 
 * You can click on "Email Link" to start a new email message in your default email client with the permalink already included in the message body.
 

--- a/doc/quickstart/opencpn_quickstart.rst
+++ b/doc/quickstart/opencpn_quickstart.rst
@@ -29,7 +29,7 @@ Setting up your charts
 Before running OpenCPN on the LiveDVD you should activate the sample data.
 This is a condition of redistributing NOAA's free nautical charts. The first time you open OpenCPN you are presented with the option to do this automatically.
 
-#. From the Start menu, select :menuselection:`Geospatial --> Navigation and Maps --> OpenCPN`.
+#. From the Start menu, select |menu_opencpn|.
 #. Click :guilabel:`I agree` to the NOAA Nautical Chart Data Agreement.
 #. Click :guilabel:`OK` to agree to the OpenCPN license.
 

--- a/doc/quickstart/osgeolive_quickstart.rst
+++ b/doc/quickstart/osgeolive_quickstart.rst
@@ -17,12 +17,12 @@ Your computer should have at least:
 
 * RAM: minimum 2 GB (4 GB recommended).
 * CPU: 1 GHz 64 bit.
-* Hard Disk: 
+* Hard Disk:
 
- * None required if running directly from the DVD 
- * |osgeolive-hdspace| if you wish to install the operating system. 
+ * None required if running directly from the DVD
+ * |osgeolive-hdspace| if you wish to install the operating system.
 
-* Mouse: a 3-button mouse is useful, especially for Mac trackpad users. 
+* Mouse: a 3-button mouse is useful, especially for Mac trackpad users.
 
 Run:
 --------------------------------------------------------------------------------
@@ -45,7 +45,7 @@ Run:
      :scale: 70 %
      :alt: boot select
 
-  Try the many applications from the :menuselection:`Geospatial` menu. 
+  Try the many applications from the :menuselection:`Geospatial` menu.
 
 See Also:
 --------------------------------------------------------------------------------

--- a/doc/quickstart/postgis_quickstart.rst
+++ b/doc/quickstart/postgis_quickstart.rst
@@ -696,7 +696,7 @@ Results might look like these:
 
 .. rubric:: Create a FDW to a WFS
 
-Start Geoserver via :menuselection:`Geospatial --> Web Services --> GeoServer -->  Start GeoServer`
+Start Geoserver via |menu_geoserver-Start|.
 
 * Open GeoServer http://localhost:8082/geoserver/web/
 * GeoServer WFS GetCapabilities http://localhost:8082/geoserver/ows?service=wfs&version=2.0.0&request=GetCapabilities

--- a/doc/quickstart/qgis_mapserver_quickstart.rst
+++ b/doc/quickstart/qgis_mapserver_quickstart.rst
@@ -23,7 +23,7 @@ This Quick Start describes how to:
 
   * update an existing QGIS project and render it with QGIS Server
   * create a new QGIS project and open the WMS directly in a browser
-  
+
 .. contents:: Contents
    :local:
 
@@ -33,8 +33,8 @@ Start GeoExt viewer
 
 OSGeoLive contains an example of web map viewer based on the GeoExt Javascript framework and using QGIS Server for rendering the map.
 
-#. Click :menuselection:`Geospatial --> Web Services --> QGIS Server`. You should see a browser window with a web map viewer showing a world map.
-   
+#. Click |menu_qgis|. You should see a browser window with a web map viewer showing a world map.
+
 .. image:: /images/projects/qgis/qgis_mapserver_browser.jpg
 
 Alternatively, you can access the application using a browser through http://localhost/qgis_server
@@ -46,14 +46,14 @@ Edit QGIS project
 
 We will now change the map styling using QGIS.
 
-#. Click :menuselection:`Geospatial --> Desktop GIS --> QGIS`.
+#. Click |menu_qgis|
 
 #. Choose :menuselection:`Project --> Open` from the menu bar.
 
 #. Select :file:`QGIS-NaturalEarth-Example.qgs` and press :guilabel:`Open`.
 
    * You should see the same world map rendered by QGIS.
-     We will now change river styling and look at the result in the web map viewer. 
+     We will now change river styling and look at the result in the web map viewer.
 
 #. Double click :file:`ne_10m_rivers_lake_centerlines` in the Layers tree.
 

--- a/doc/quickstart/qgis_quickstart.rst
+++ b/doc/quickstart/qgis_quickstart.rst
@@ -296,7 +296,7 @@ Things to try
 
 * Try publishing your QGIS map to the web using :doc:`QGIS Map Server
   <../overview/qgis_mapserver_overview>`. in the
-  :menuselection:`Geospatial --> Web Services` menu.
+  |menu_qgis-server|
 
 
 What next?

--- a/doc/quickstart/re3gistry_quickstart.rst
+++ b/doc/quickstart/re3gistry_quickstart.rst
@@ -30,8 +30,8 @@ This Quick Start describes how to:
 Start the Re3gistry
 ================================================================================
 
-Choose *'Start Re3gistry'* from the :menuselection:`Geospatial --> Web Services
---> Re3gistry` menu.  The application will take a few moments to start up.
+Choose *'Start Re3gistry'* from the |menu_re3gistry-Start|
+menu.  The application will take a few moments to start up.
 Firefox opens the *Re3gistry landing page* (you can also open this manually by
 pointing your browser to http://localhost:8080/re3gistry2).
 

--- a/doc/quickstart/sahana_quickstart.rst
+++ b/doc/quickstart/sahana_quickstart.rst
@@ -15,14 +15,14 @@
 Getting Started
 ================================================================================
 
-Sahana Eden is already installed and configured when you start OSGeoLive. To access Sahana Eden click on the :menuselection:`Geospatial menu --> Crisis Management --> Sahana`. If you started it earlier you can simply `click here <http://127.0.0.1:8007/eden>`_. By default, you will have view-only rights to access the data. If you wish to create new records, or edit existing records, you will need to be logged in as a user - use the following credentials to get started.
+Sahana Eden is already installed and configured when you start OSGeoLive. To access Sahana Eden click on the |menu_sahana|. If you started it earlier you can simply `click here <http://127.0.0.1:8007/eden>`_. By default, you will have view-only rights to access the data. If you wish to create new records, or edit existing records, you will need to be logged in as a user - use the following credentials to get started.
 
 * E-mail: admin
 * Password: admin
 
-If you have entered example crowd-sourced data in Ushahidi, then you can access that information in Sahana Eden by `following this link <http://127.0.0.1:8007/eden/irs/ireport/ushahidi>`_. 
+If you have entered example crowd-sourced data in Ushahidi, then you can access that information in Sahana Eden by `following this link <http://127.0.0.1:8007/eden/irs/ireport/ushahidi>`_.
 
-You will find it has already been configured to access the map data and map servers that are part of OSGeoLive. Sahana Eden can utilise OpenStreetMap as an underlying map layer in the `map viewing client <http://127.0.0.1:8007/eden/gis/map_viewing_client>`_. Sahana Eden supports a wide range of OpenStreetMap services. 
+You will find it has already been configured to access the map data and map servers that are part of OSGeoLive. Sahana Eden can utilise OpenStreetMap as an underlying map layer in the `map viewing client <http://127.0.0.1:8007/eden/gis/map_viewing_client>`_. Sahana Eden supports a wide range of OpenStreetMap services.
 
 Development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -30,7 +30,7 @@ Development
 Sahana Eden is always looking for more developers to join and contribute to our project. The primary development platform is the `Python <http://www.python.org/>`_ programming language and the `web2py <http://www.web2py.com/>`_ Enterprise Web Framework. We additionally are looking for contributors with skills in mapping, jquery and javascript.
 
 * `Want to help Develop Sahana Eden? <http://eden.sahanafoundation.org/wiki/Develop>`_
-* `Ticket System <http://eden.sahanafoundation.org/report/1>`_ - for reporting problems 
+* `Ticket System <http://eden.sahanafoundation.org/report/1>`_ - for reporting problems
 
 Further reading
 ================================================================================

--- a/doc/quickstart/spatialite_quickstart.rst
+++ b/doc/quickstart/spatialite_quickstart.rst
@@ -8,7 +8,7 @@
 
 
 .. TBD: Cameron Review
-  We need to explain in words what we aim to achieve by each 
+  We need to explain in words what we aim to achieve by each
   step. Eg: "Let's find all Villas which include have a geometry and ..."
   This will require an extra sentence for most steps.
 
@@ -23,7 +23,7 @@
 @NAME_spatialite@ Quickstart
 ********************************************************************************
 
-SpatiaLite is an SQLite database engine with spatial functions added. 
+SpatiaLite is an SQLite database engine with spatial functions added.
 
 SQLite is a Database Management System (DBMS) which is simple, robust, easy to use and very lightweight. Each SQLite database is simply a file. You can freely copy it, compress it, and port it between Windows, Linux, MacOs etc.
 
@@ -31,7 +31,7 @@ This Quick Start describes how to open a spatialite database from both GUI appli
 
 .. contents:: Contents
    :local:
-  
+
 Start Spatialite and load a database
 ====================================
 
@@ -40,7 +40,7 @@ spatialite database. You can easily see the structure of the tables and data
 contents using point and click functions, many of which construct
 common SQL queries, or craft your own SQL queries.
 
-#. Open the Spatialite GUI by selecting :menuselection:`Geospatial->Databases->Spatialite GUI`.
+#. Open the Spatialite GUI by selecting |menu_spatialite-gui|
 
    .. TBD: Cameron Review Comment: We should have continuity in our examples. Ie, Use the same scenario for all   spaital-gui steps. Use the same table, where each step builds upon the previous step. I'd suggest our examples should aim to have a GIS focus to them too.
 
@@ -96,7 +96,7 @@ Run an SQL query
 Run spatialite from the command line
 ====================================
 
-Users needing to script or automate queries will learn the advantages of working with a spatialite database from the command line interface. In this example, we will load a shapefile, and search for schools which are near highway 42. 
+Users needing to script or automate queries will learn the advantages of working with a spatialite database from the command line interface. In this example, we will load a shapefile, and search for schools which are near highway 42.
 
 #. Before working from the command line, we need to open a terminal window: :menuselection:`System Tools -> LXTerminal`.
 
@@ -106,7 +106,7 @@ Users needing to script or automate queries will learn the advantages of working
 
 
    Helpful commands from the command line::
-    
+
      .help
      .tables
      .quit
@@ -114,7 +114,7 @@ Users needing to script or automate queries will learn the advantages of working
 
 Create a new spatialite database and load a shapefile
 =====================================================
-  
+
 #. Let's create a new, empty spatialite database, and load two shapefiles from the north_carolina dataset::
 
       user@osgeo-6:~$ spatialite test.sqlite
@@ -146,7 +146,7 @@ Create a new spatialite database and load a shapefile
       SQLite version 3.31.1 2020-01-27 19:55:54
       Enter ".help" for instructions
       Enter SQL statements terminated with a ";"
-      spatialite>       
+      spatialite>
       spatialite> .loadshp data/north_carolina/shape/schools_wake schools utf-8 3358
       spatialite> .loadshp data/north_carolina/shape/roadsmajor roads utf-8 3358
 
@@ -154,7 +154,7 @@ Create a new spatialite database and load a shapefile
    Note the format of the .loadshp command: first the shapefile without the .shp extension, then the name of the new spatialite table, next the character encoding, and finally the EPSG code of the shapefile's CRS.
 
 #. Now we'll query for schools near to highway 42.::
- 
+
       spatialite> SELECT s.NAMESHORT, s.ADDRNUMBER, s.ADDRROOT
            ...> FROM schools AS s, roads AS r
            ...> WHERE r.ROAD_NAME = "NC-42" AND
@@ -173,7 +173,7 @@ Create a new spatialite database and load a shapefile
           ...> WHERE r.ROAD_NAME = "NC-42" AND
           ...> ST_Distance(s.Geometry, r.Geometry) < 1000;
       spatialite>.q
- 
+
 
 
 Things to try

--- a/doc/quickstart/t-rex_quickstart.rst
+++ b/doc/quickstart/t-rex_quickstart.rst
@@ -26,10 +26,10 @@ This Quick Start describes how to:
 .. contents:: Contents
    :local:
 
-Start T-Rex 
+Start T-Rex
 ============
 
-Choose :menuselection:`Geospatial --> Web Services --> T-Rex` from the menu.
+Choose |menu_t-rex|.
 
 This starts t-rex in zero-config mode connecting to PostGIS database `osm_local`. A browser window is opened showing the t-rex backend.
 
@@ -48,7 +48,7 @@ t-rex comes with built-in viewers for inspecting generated vector tiles.
   .. image:: /images/projects/t-rex/backend-x-ray.png
    :scale: 50 %
 
-Try also the other viewers. 
+Try also the other viewers.
 
 .. note:: The Mapbox GL viewer and Maputnik require WebGL support, which is probably not available when running OSGeoLive in a VM.
 

--- a/doc/quickstart/zoo-project_quickstart.rst
+++ b/doc/quickstart/zoo-project_quickstart.rst
@@ -21,12 +21,12 @@ A WPS provides web access to functions which run spatial algorithms.
 
 .. contents:: Contents
    :local:
-  
+
 
 Start ZOO-Project
 =================
 
-From the Start menu, select :menuselection:`Geospatial --> Web Services --> ZOO Project`.
+From the Start menu, select |menu_zoo-project|.
 
 Firefox will open the ZOO Project demonstration landing page. From here, you can select a demon application.
 
@@ -46,7 +46,7 @@ OGR spatial tools demo
     :scale: 50 %
     :alt: screenshot
     :align: center
-  
+
 
 #. Now select another feature near the first you've selected, then click on a multiple geometries process button like Union, Intersection, Symmetric Difference or Difference to get the result displayed in red on the map.
 
@@ -72,8 +72,8 @@ OTB Applications demo
 =====================
 
 #. On the ZOO Project demonstration landing page, click :guilabel:`view` on OTB application.
-#. Fill the form on the left to configure the WPS service execution. 
-#. Once you have selected the values for your processing, press the :guilabel:`Execute` button at the bottom of the left form. 
+#. Fill the form on the left to configure the WPS service execution.
+#. Once you have selected the values for your processing, press the :guilabel:`Execute` button at the bottom of the left form.
 #. If you chose image/png as the output format, you will see the result of your processing displayed on the map. You can see below a sample KMeansClassification execution when selecting the image/png output format.
 
    .. image:: /images/projects/zoo-project/zoo-demo-1.png
@@ -88,6 +88,6 @@ What next?
 
 *	You can access the capabilities of the ZOO WPS Server:
 		http://localhost/cgi-bin/zoo_loader.cgi?Request=GetCapabilities&Service=WPS
-	
+
 *	For further questions you can contact the ZOO Project mailing list:
 	zoo-discuss@lists.osgeo.org

--- a/menuselections.conf
+++ b/menuselections.conf
@@ -1,0 +1,64 @@
+.. |menu_grass82| replace:: :menuselection:`Geospatial --> Desktop GIS --> GRASS GIS 8`
+.. |menu_qgis| replace:: :menuselection:`Geospatial --> Desktop GIS --> QGIS Desktop`
+.. |menu_gvsig| replace:: :menuselection:`Geospatial --> Desktop GIS --> gvSIG desktop`
+.. |menu_openjump| replace:: :menuselection:`Geospatial --> Desktop GIS --> OpenJUMP`
+.. |menu_uDig| replace:: :menuselection:`Geospatial --> Desktop GIS --> uDig`
+.. |menu_saga| replace:: :menuselection:`Geospatial --> Desktop GIS --> SAGA GIS`
+.. |menu_marble| replace:: :menuselection:`Geospatial --> Navigation and Maps --> Marble`
+.. |menu_opencpn| replace:: :menuselection:`Geospatial --> Navigation and Maps --> OpenCPN`
+.. |menu_josm| replace:: :menuselection:`Geospatial --> Navigation and Maps --> OpenStreetMap --> JOSM`
+.. |menu_osm_online| replace:: :menuselection:`Geospatial --> Navigation and Maps --> OpenStreetMap --> View OSM online`
+.. |menu_xygrib| replace:: :menuselection:`Geospatial --> Navigation and Maps --> XyGrib GRIB file viewer`
+.. |menu_gpsprune| replace:: :menuselection:`Geospatial --> Navigation and Maps --> GpsPrune`
+.. |menu_deegree-Start| replace:: :menuselection:`Geospatial --> Web Services --> deegree --> Start deegree`
+.. |menu_deegree-Stop| replace:: :menuselection:`Geospatial --> Web Services --> deegree --> Stop deegree`
+.. |menu_geoserver-Start| replace:: :menuselection:`Geospatial --> Web Services --> GeoServer --> Start GeoServer`
+.. |menu_geoserver-Stop| replace:: :menuselection:`Geospatial --> Web Services --> GeoServer --> Stop GeoServer`
+.. |menu_geoserver-Admin| replace:: :menuselection:`Geospatial --> Web Services --> GeoServer --> Admin GeoServer`
+.. |menu_geoserver-GeoServer| replace:: :menuselection:`Geospatial --> Web Services --> GeoServer --> GeoServer documentation`
+.. |menu_geonetwork-Admin| replace:: :menuselection:`Geospatial --> Web Services --> GeoNetwork --> Admin GeoNetwork`
+.. |menu_geonetwork-Start| replace:: :menuselection:`Geospatial --> Web Services --> GeoNetwork --> Start GeoNetwork`
+.. |menu_geonetwork-Stop| replace:: :menuselection:`Geospatial --> Web Services --> GeoNetwork --> Stop GeoNetwork`
+.. |menu_mapserver| replace:: :menuselection:`Geospatial --> Web Services --> MapServer`
+.. |menu_mapcache| replace:: :menuselection:`Geospatial --> Web Services --> MapCache`
+.. |menu_mapproxy-Start| replace:: :menuselection:`Geospatial --> Web Services --> MapProxy --> Start MapProxy`
+.. |menu_mapproxy-MapProxy| replace:: :menuselection:`Geospatial --> Web Services --> MapProxy --> MapProxy Introduction`
+.. |menu_qgis-server| replace:: :menuselection:`Geospatial --> Web Services --> QGIS Server`
+.. |menu_zoo-project| replace:: :menuselection:`Geospatial --> Web Services --> ZOO Project`
+.. |menu_52nSOS-Start| replace:: :menuselection:`Geospatial --> Web Services --> 52North --> Start 52NorthSOS`
+.. |menu_52nSOS-Stop| replace:: :menuselection:`Geospatial --> Web Services --> 52North --> Stop 52NorthSOS`
+.. |menu_52nWPS-Start| replace:: :menuselection:`Geospatial --> Web Services --> 52North --> Start 52NorthWPS`
+.. |menu_52nWPS-Stop| replace:: :menuselection:`Geospatial --> Web Services --> 52North --> Stop 52NorthWPS`
+.. |menu_eoxserver| replace:: :menuselection:`Geospatial --> Web Services --> EOxServer`
+.. |menu_ncWMS-Start| replace:: :menuselection:`Geospatial --> Web Services --> ncWMS --> Start ncWMS2`
+.. |menu_ncWMS-Stop| replace:: :menuselection:`Geospatial --> Web Services --> ncWMS --> Stop ncWMS2`
+.. |menu_pycsw| replace:: :menuselection:`Geospatial --> Web Services --> pycsw`
+.. |menu_istsos| replace:: :menuselection:`Geospatial --> Web Services --> istSOS`
+.. |menu_pywps| replace:: :menuselection:`Geospatial --> Web Services --> PyWPS`
+.. |menu_t-rex| replace:: :menuselection:`Geospatial --> Web Services --> T-Rex`
+.. |menu_actinia-Start| replace:: :menuselection:`Geospatial --> Web Services --> actinia --> Start Actinia`
+.. |menu_pygeoapi-Start| replace:: :menuselection:`Geospatial --> Web Services --> pygeoapi --> Start pygeoapi`
+.. |menu_pygeoapi-pygeoapi| replace:: :menuselection:`Geospatial --> Web Services --> pygeoapi --> pygeoapi Introduction`
+.. |menu_re3gistry-Start| replace:: :menuselection:`Geospatial --> Web Services --> re3gistry --> Start INSPIRE Re3gistry`
+.. |menu_re3gistry-Stop| replace:: :menuselection:`Geospatial --> Web Services --> re3gistry --> Stop INSPIRE Re3gistry`
+.. |menu_-Start| replace:: :menuselection:`Geospatial --> Web Services --> ETF --> Start ETF`
+.. |menu_-Stop| replace:: :menuselection:`Geospatial --> Web Services --> ETF --> Stop ETF`
+.. |menu_openlayers| replace:: :menuselection:`Geospatial --> Browser Clients --> OpenLayers`
+.. |menu_cesium| replace:: :menuselection:`Geospatial --> Browser Clients --> Cesium`
+.. |menu_leaflet| replace:: :menuselection:`Geospatial --> Browser Clients --> Leaflet`
+.. |menu_mapbender| replace:: :menuselection:`Geospatial --> Browser Clients --> Mapbender`
+.. |menu_GeoMoose3| replace:: :menuselection:`Geospatial --> Browser Clients --> GeoMoose 3`
+.. |menu_geonode-Admin| replace:: :menuselection:`Geospatial --> Browser Clients --> GeoNode --> Admin GeoNode`
+.. |menu_geonode-Start| replace:: :menuselection:`Geospatial --> Browser Clients --> GeoNode --> Start GeoNode`
+.. |menu_geonode-Stop| replace:: :menuselection:`Geospatial --> Browser Clients --> GeoNode --> Stop GeoNode`
+.. |menu_geoext| replace:: :menuselection:`Geospatial --> Browser Clients --> GeoExt`
+.. |menu_geostyler| replace:: :menuselection:`Geospatial --> Browser Clients --> GeoStyler`
+.. |menu_R Statistics| replace:: :menuselection:`Geospatial --> Spatial Tools --> R Statistics`
+.. |menu_Jupyter Notebook| replace:: :menuselection:`Geospatial --> Spatial Tools --> Jupyter Notebook`
+.. |menu_OTB Launcher| replace:: :menuselection:`Geospatial --> Spatial Tools --> OTB Launcher`
+.. |menu_Monteverdi| replace:: :menuselection:`Geospatial --> Spatial Tools --> Monteverdi`
+.. |menu_spatialite-gui| replace:: :menuselection:`Geospatial --> Databases --> Spatialite GUI`
+.. |menu_rasdaman-Start| replace:: :menuselection:`Geospatial --> Databases --> Rasdaman --> Start Rasdaman Server`
+.. |menu_rasdaman-Stop| replace:: :menuselection:`Geospatial --> Databases --> Rasdaman --> Stop Rasdaman Server`
+.. |menu_rasdaman-Rasdaman-Earthlook| replace:: :menuselection:`Geospatial --> Databases --> Rasdaman --> Rasdaman-Earthlook Demo`
+.. |menu_phppgadmin| replace:: :menuselection:`Geospatial --> Databases --> phpPgAdmin`


### PR DESCRIPTION

Based on OSGeoLive files to build the disk:
- Captured the menu structure
- Saved into a file as menu selection statements

```
.. |menu_grass| replace:: :menuselection:`Geospatial --> Desktop GIS --> GRASS GIS 8`
```

- Included that file on the epilogue of doc/conf.py
- Changed the menu selection statements on the documentation
```
Click on |menu_grass|
```
- fixed some broken links
- I added more examples and reformatted to 80 columns the _template_quickstart.rst file