### PR TITLE
GitHub actions: update to current versions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -13,11 +13,11 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: ${{ github.repository_owner == 'OSGeo' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install apt packages
         run: |
@@ -25,7 +25,7 @@ jobs:
           sudo cpanm Text::SimpleTable::AutoWidth
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,7 +15,7 @@ jobs:
           language: [de,en,es,fi,fr,hu,ja,it]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -32,7 +32,7 @@ jobs:
            
       - name: Install python
         if: env.PROCESS == 'true'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
At time warnings about outdated action versions appear in [Actions](https://github.com/OSGeo/OSGeoLive-doc/actions):

`
Build (de)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16 ...`

This PR updates various action versions.