### PR TITLE
Pin requirements.txt for Sphinx 4.x

### DIFF
--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -32,7 +32,7 @@ assistance. You also can meet us at Slack, Matrix or Gitter.
 A wealth of information is available on our `Wiki site <https://trac.osgeo.org/osgeolive/wiki>`_, 
 and a `bug and wish tracking system <https://trac.osgeo.org/osgeolive/report/10>`_ is also available.
 
-Stay tuned and follow OSGeoLive on Twitter `@osgeolive <https://mobile.twitter.com/osgeolive>`_.
+Stay tuned and follow OSGeoLive on Twitter `@osgeolive <https://twitter.com/osgeolive>`_.
 
 Commercial Support
 ================================================================================

--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -32,7 +32,7 @@ assistance. You also can meet us at Slack, Matrix or Gitter.
 A wealth of information is available on our `Wiki site <https://trac.osgeo.org/osgeolive/wiki>`_, 
 and a `bug and wish tracking system <https://trac.osgeo.org/osgeolive/report/10>`_ is also available.
 
-Stay tuned and follow OSGeoLive on Twitter `@osgeolive <https://twitter.com/osgeolive>`_.
+Stay tuned and follow OSGeoLive on Mastodon `@osgeolive <https://fosstodon.org/@osgeolive>`_.
 
 Commercial Support
 ================================================================================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,7 +3,7 @@ Welcome to |osgeolive-version|
 ================================================================================
 
 `OSGeoLive <https://live.osgeo.org>`_ is a self-contained bootable DVD, USB
-thumb drive or Virtual Machine based on `Lubuntu <https://lubuntu.net>`_,
+thumb drive or Virtual Machine based on `Lubuntu <https://lubuntu.me>`_,
 that allows you to try a wide variety of open
 source geospatial software without installing anything. It is composed
 entirely of free software, allowing it to be freely distributed, duplicated

--- a/doc/quickstart/mapbender_quickstart.rst
+++ b/doc/quickstart/mapbender_quickstart.rst
@@ -159,7 +159,7 @@ Now you should get an idea how easy it is to change a Mapbender application with
   .. image:: /images/projects/mapbender/mapbender3_application_elements.png
      :scale: 70 %
 
-You find detailed information on every element in the `Mapbender element documentation <https://doc.mapbender.org/en/functions.html>`_.
+You find detailed information on every element in the `Mapbender element documentation <https://doc.mapbender.org/en/elements.html>`_.
 
 
 Things to try

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 sphinx==4.3.2
 sphinx-intl>=2.0.0
 sphinx-revealjs
-sphinx-intl[transifex]
+sphinx-intl
 transifex-client


### PR DESCRIPTION
There are currently build issues (see https://github.com/OSGeo/OSGeoLive-doc/actions) due to changes in Sphinx extensions. 

```
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```

See https://stackoverflow.com/questions/77848565/sphinxcontrib-applehelp-breaking-sphinx-builds-with-sphinx-version-less-than-5-0 (fixing the first error produces similar errors for the other extensions). 

This pull request pins the older versions to ensure the docs build correctly. 

In addition, there is the following warning:

```
sphinx-intl[transifex]
WARNING: sphinx-intl 2.1.0 does not provide the extra 'transifex'
```

This additional option no longer seems to exist and appears to be handled by the transifex-client. I've removed the option. 

Now `sphinx-revealjs` is used, I'm not sure if there is still a requirement to pin Sphinx to 4.3.2, but updating would likely require other changes / discussions. 