### PR TITLE
Add styling for the admonition.note

### DIFF
--- a/doc/_themes/overview/static/overview.css
+++ b/doc/_themes/overview/static/overview.css
@@ -376,10 +376,21 @@ img.align-center, .figure.align-center, object.align-center {
 div.document {
     background-color: white;
     text-align: left;
-    //background-image: none;
-   // background-repeat: repeat-x;
+/*    background-image: none;
+    background-repeat: repeat-x;*/
 }
 
 div.related {
   text-align: center;
+}
+
+.admonition.note {
+  background-color: #f5f5f5;
+  border-left: 4px solid #007BFF;
+  padding: 10px;
+  margin: 10px 0;
+}
+
+.admonition-title {
+  font-weight: bold;
 }


### PR DESCRIPTION
Currently, RST note blocks don't have any formatting (as there is no style applied to the docs):

```rst
.. note::

  A complete list of the available objects and properties a Mapfile can have
  can be found in the `MapServer documentation page
  <https://mapserver.org/mapfile/index.html>`_.
```

This pull request changes the HTML output (for all pages) from plain text:

![image](https://github.com/user-attachments/assets/8c9a0926-6d2c-4299-90b9-7ccaf1f03cb6)

To a formatted section:

![image](https://github.com/user-attachments/assets/165197a2-07ba-4ee5-a399-449acb6b86f9)

Happy to change the styling, or close this pull request if plain text is preferred. Most Sphinx themes however implement a similar style for `.. note::`.

Also fix a commented out CSS (``//`` isn't valid). 