### PR TITLE
GDAL Quickstart and Overview updates

### DIFF
--- a/doc/overview/gdal_overview.rst
+++ b/doc/overview/gdal_overview.rst
@@ -35,8 +35,8 @@ Core Features
 * Command-line utilities for data translation, image warping, subsetting, and various other common tasks
 * Highly efficient raster data access, taking advantage of tiling and overviews
 * Support for large files - larger than 4GB
-* Library access from Python, Java, C#, Ruby, VB6 and Perl
-* Coordinate system engine built on PROJ.4 and OGC Well Known Text coordinate system descriptions
+* Library access from Python, Java, and C#
+* Coordinate system engine built on PROJ and OGC Well Known Text coordinate system descriptions
 
 Popular Supported Formats
 --------------------------------------------------------------------------------
@@ -45,8 +45,8 @@ GDAL supports over 140 raster formats, and OGR over 80 vector formats.
 
 These include:
 
-* **Raster:** GeoTIFF, Erdas Imagine, SDTS, ESRI Grids, ECW, MrSID, JPEG2000, DTED, NITF, GeoPackage and more ...
-* **Vector:** GeoPackage, ESRI Shapefile, GML, GeoJSON, AutoCAD DWG, MapInfo (tab and mid/mif), ESRI Coverages, ESRI Personal Geodatabase, DGN, PostGIS, Oracle Spatial, and more ...
+* **Raster:** GeoTIFF / COG, HDF, NetCDF, GeoPackage, JPEG2000, ECW, ENVI, KEA, MrSID, DTED, NITF and more ...
+* **Vector:** GeoPackage, ESRI Shapefile, GeoJSON, PostGIS, (Geo)Parquet, ESRI File Geodatabase, FlatGeobuf, GML, AutoCAD DWG, MapInfo, DGN, Oracle Spatial, and more ...
 
 Implemented Standards
 --------------------------------------------------------------------------------
@@ -64,7 +64,7 @@ Details
 
 **Supported Platforms:** Windows, Linux, Mac
 
-**API Interfaces:** C, C++, Python, Java, C#, Ruby, VB6 and Perl
+**API Interfaces:** C, C++, Python, Java, C#
 
 **Support:** https://lists.osgeo.org/mailman/listinfo/gdal-dev, https://www.osgeo.org/service-providers/
 

--- a/doc/quickstart/gdal_quickstart.rst
+++ b/doc/quickstart/gdal_quickstart.rst
@@ -56,7 +56,8 @@ directory.
 You will then find a NaturalEarth Raster file and a .tfw World-file at:
 ::
 
- ls /home/user/gdal_natural_earth/HYP_50M_SR_W.*
+ cd /home/user/gdal_natural_earth
+ ls HYP_50M_SR_W.*
 
 
 .. tip:: Open the file with a Desktop GIS like QGIS, and have a look.
@@ -68,28 +69,35 @@ Get information about the raster data with gdalinfo
       gdalinfo HYP_50M_SR_W.tif
 	Driver: GTiff/GeoTIFF
 	Files: HYP_50M_SR_W.tif
-	       HYP_50M_SR_W.tfw
 	Size is 10800, 5400
-	Coordinate System is `'
+	Coordinate System is:
+	GEOGCRS["WGS 84",
+	    ENSEMBLE["World Geodetic System 1984 ensemble",
+      ...
 	Origin = (-179.999999999999972,90.000000000000000)
 	Pixel Size = (0.033333333333330,-0.033333333333330)
 	Metadata:
-	  TIFFTAG_SOFTWARE=Adobe Photoshop CS3 Macintosh
-	  TIFFTAG_DATETIME=2009:09:19 10:13:17
+	  TIFFTAG_SOFTWARE=Adobe Photoshop CS5 Macintosh
+	  TIFFTAG_DATETIME=2012:07:16 09:16:14
 	  TIFFTAG_XRESOLUTION=342.85699
 	  TIFFTAG_YRESOLUTION=342.85699
 	  TIFFTAG_RESOLUTIONUNIT=2 (pixels/inch)
+	  AREA_OR_POINT=Area
 	Image Structure Metadata:
+	  SOURCE_COLOR_SPACE=YCbCr
+	  COMPRESSION=YCbCr JPEG
 	  INTERLEAVE=PIXEL
+	  JPEG_QUALITY=90
+	  JPEGTABLESMODE=3
 	Corner Coordinates:
-	Upper Left  (-180.0000000,  90.0000000)
-	Lower Left  (-180.0000000, -90.0000000)
-	Upper Right ( 180.0000000,  90.0000000)
-	Lower Right ( 180.0000000, -90.0000000)
-	Center      (  -0.0000000,   0.0000000)
-	Band 1 Block=10800x1 Type=Byte, ColorInterp=Red
-	Band 2 Block=10800x1 Type=Byte, ColorInterp=Green
-	Band 3 Block=10800x1 Type=Byte, ColorInterp=Blue
+	Upper Left  (-180.0000000,  90.0000000) (180d 0' 0.00"W, 90d 0' 0.00"N)
+	Lower Left  (-180.0000000, -90.0000000) (180d 0' 0.00"W, 90d 0' 0.00"S)
+	Upper Right ( 180.0000000,  90.0000000) (180d 0' 0.00"E, 90d 0' 0.00"N)
+	Lower Right ( 180.0000000, -90.0000000) (180d 0' 0.00"E, 90d 0' 0.00"S)
+	Center      (  -0.0000000,   0.0000000) (  0d 0' 0.00"W,  0d 0' 0.00"N)
+	Band 1 Block=256x256 Type=Byte, ColorInterp=Red
+	Band 2 Block=256x256 Type=Byte, ColorInterp=Green
+	Band 3 Block=256x256 Type=Byte, ColorInterp=Blue
 
 Note:
   * Driver is "GTiff/GeoTIFF"
@@ -103,19 +111,21 @@ Note:
 Simple format translation
 =========================
 
-First get to know your drivers. The `--formats` commandline switch of
+First get to know your drivers. The `--formats` command line switch of
 gdal_translate can be used to see a list of available format drivers.
 
-Each format reports if it is
-  * read only (ro),
-  * read/write (rw) or
-  * read/write/update (rw+).
+Each format reports if it supports the following features:
+  * read only (ro)
+  * read/write (rw)
+  * read/write/update (rw+)
+  * supports virtual file systems (v)
+  * supports subdatasets (s)
 
 ::
 
  gdal_translate --formats
 
-The `--format` commandline switch can be used to query details about a
+The `--format` command line switch can be used to query details about a
 particular driver, including creation options, and permitted data types.
 
 ::
@@ -193,31 +203,29 @@ will learn more about ogrinfo later in this tutorial)
       using driver `ESRI Shapefile' successful.
 
   Layer name: index_natural_earth
+  Metadata:
+    DBF_DATE_LAST_UPDATE=2025-05-13
   Geometry: Polygon
   Feature Count: 2
   Extent: (-180.000000, -90.000000) - (180.000000, 90.000000)
-  Layer SRS WKT: (unknown)
-  location: String (255.0)
+  Layer SRS WKT:
+  GEOGCRS["WGS 84",
+      ...
+  location: String (254.0)
   OGRFeature(index_natural_earth):0
-    location (String) = east.tif
-    POLYGON ((-0.00000000001796 90.0,179.999999999964047 90.0,179.999999999964047 -89.999999999982009,-0.00000000001796 -89.999999999982009,-0.00000000001796 90.0))
+    location (String) = west.tif
+    POLYGON ((-180 90.0,-0.000000000017963 90.0,-0.000000000017963 -89.999999999982,-180 -89.999999999982,-180 90.0))
 
   OGRFeature(index_natural_earth):1
-    location (String) = west.tif
-    POLYGON ((-179.999999999999972 90.0,-0.00000000001796 90.0,-0.00000000001796 -89.999999999982009,-179.999999999999972 -89.999999999982009,-179.999999999999972 90.0))
+    location (String) = east.tif
+    POLYGON ((-0.000000000017963 90.0,179.999999999964 90.0,179.999999999964 -89.999999999982,-0.000000000017963 -89.999999999982,-0.000000000017963 90.0))
 
 
 Reprojecting
 ============
 
 For this process we assume that HYP_50M_SR_W.tif has been properly
-created with bounds. As we saw before with gdainfo no coordinate system
-was set. So we assign WGS84 as coordinate system to the image in the
-first step.
-
-::
-
-     gdal_translate -a_srs WGS84 HYP_50M_SR_W.tif HYP_50M_SR_W_4326.tif
+created with bounds.
 
 The gdalwarp command can be used to reproject images. Here we reproject
 the WGS84 geographic image to the Mercator projection:
@@ -285,18 +293,19 @@ Get information about the vector data with ogrinfo
   ogrinfo -ro /home/user/gdal_natural_earth
   INFO: Open of `/home/user/gdal_natural_earth'
         using driver `ESRI Shapefile' successful.
-    1: ne_10m_populated_places (3D Point)
-    2: ne_10m_geography_regions_polys (3D Polygon)
-    3: ne_10m_admin_1_states_provinces_shp (3D Polygon)
-    4: ne_10m_urban_areas (3D Polygon)
-    5: ne_10m_geography_marine_polys (3D Polygon)
-    6: ne_10m_land (3D Polygon)
-    7: ne_10m_geography_regions_elevation_points (3D Point)
-    8: ne_10m_admin_0_countries (3D Polygon)
-    9: ne_10m_rivers_lake_centerlines (3D Line String)
-    10: ne_10m_lakes (3D Polygon)
-    11: ne_10m_geography_regions_points (3D Point)
-    12: ne_10m_ocean (3D Polygon)
+  1: ne_10m_geography_regions_polys (Polygon)
+  2: ne_10m_populated_places (Point)
+  3: ne_10m_urban_areas (Polygon)
+  4: ne_10m_geography_marine_polys (Polygon)
+  5: ne_10m_admin_1_states_provinces_shp (Polygon)
+  6: ne_10m_admin_0_countries (Polygon)
+  7: ne_10m_ocean (Polygon)
+  8: ne_10m_rivers_lake_centerlines (Line String)
+  9: ne_10m_land (Polygon)
+  10: index_natural_earth (Polygon)
+  11: ne_10m_geography_regions_elevation_points (Point)
+  12: ne_10m_geography_regions_points (Point)
+  13: ne_10m_lakes (Polygon)
 
 
 Get a summary about your data with ogrinfo together with `-so`.
@@ -308,15 +317,15 @@ Get a summary about your data with ogrinfo together with `-so`.
 	      using driver `ESRI Shapefile' successful.
 
 	Layer name: ne_10m_admin_0_countries
-	Geometry: 3D Polygon
+	Metadata:
+	  DBF_DATE_LAST_UPDATE=2012-11-05
+	Geometry: Polygon
 	Feature Count: 254
 	Extent: (-180.000000, -90.000000) - (180.000000, 83.634101)
 	Layer SRS WKT:
-	GEOGCS["GCS_WGS_1984",
-	    DATUM["WGS_1984",
-		SPHEROID["WGS_84",6378137.0,298.257223563]],
-	    PRIMEM["Greenwich",0.0],
-	    UNIT["Degree",0.0174532925199433]]
+	GEOGCRS["WGS 84",
+	    DATUM["World Geodetic System 1984",
+	...
 	scalerank: Integer (4.0)
 	featurecla: String (30.0)
 	labelrank: Real (16.6)

--- a/locale/en/LC_MESSAGES/overview/gdal_overview.po
+++ b/locale/en/LC_MESSAGES/overview/gdal_overview.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OSGeoLive 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-26 14:03+0000\n"
+"POT-Creation-Date: 2025-05-13 22:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: ../../build/doc/overview/gdal_overview.rst:18
 msgid "GDAL/OGR"
@@ -72,13 +72,13 @@ msgid "Support for large files - larger than 4GB"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:48
-msgid "Library access from Python, Java, C#, Ruby, VB6 and Perl"
+msgid "Library access from Python, Java, and C#"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:49
 msgid ""
-"Coordinate system engine built on PROJ.4 and OGC Well Known Text "
-"coordinate system descriptions"
+"Coordinate system engine built on PROJ and OGC Well Known Text coordinate"
+" system descriptions"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:52
@@ -95,15 +95,15 @@ msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:58
 msgid ""
-"**Raster:** GeoTIFF, Erdas Imagine, SDTS, ESRI Grids, ECW, MrSID, "
-"JPEG2000, DTED, NITF, GeoPackage and more ..."
+"**Raster:** GeoTIFF / COG, HDF, NetCDF, GeoPackage, JPEG2000, ECW, ENVI, "
+"KEA, MrSID, DTED, NITF and more ..."
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:59
 msgid ""
-"**Vector:** GeoPackage, ESRI Shapefile, GML, GeoJSON, AutoCAD DWG, "
-"MapInfo (tab and mid/mif), ESRI Coverages, ESRI Personal Geodatabase, "
-"DGN, PostGIS, Oracle Spatial, and more ..."
+"**Vector:** GeoPackage, ESRI Shapefile, GeoJSON, PostGIS, (Geo)Parquet, "
+"ESRI File Geodatabase, FlatGeobuf, GML, AutoCAD DWG, MapInfo, DGN, Oracle"
+" Spatial, and more ..."
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:62
@@ -139,7 +139,7 @@ msgid "**Supported Platforms:** Windows, Linux, Mac"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:77
-msgid "**API Interfaces:** C, C++, Python, Java, C#, Ruby, VB6 and Perl"
+msgid "**API Interfaces:** C, C++, Python, Java, C#"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:79
@@ -156,11 +156,11 @@ msgstr ""
 msgid ":doc:`Quickstart documentation <../quickstart/gdal_quickstart>`"
 msgstr ""
 
-#: ../../build/doc/<rst_epilog>:13
+#: ../../build/doc/<rst_epilog>:11
 msgid "vmdk"
 msgstr ""
 
-#: ../../build/doc/<rst_epilog>:16
+#: ../../build/doc/<rst_epilog>:14
 msgid "nologo"
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/quickstart/gdal_quickstart.po
+++ b/locale/en/LC_MESSAGES/quickstart/gdal_quickstart.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OSGeoLive 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-14 04:54+0000\n"
+"POT-Creation-Date: 2025-05-13 22:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: ../../build/doc/quickstart/gdal_quickstart.rst:21
 msgid "GDAL/OGR Quickstart"
@@ -95,109 +95,117 @@ msgstr ""
 msgid "You will then find a NaturalEarth Raster file and a .tfw World-file at: ::"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:68
+#: ../../build/doc/quickstart/gdal_quickstart.rst:69
 msgid "Open the file with a Desktop GIS like QGIS, and have a look."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:71
+#: ../../build/doc/quickstart/gdal_quickstart.rst:72
 msgid "Get information about the raster data with gdalinfo"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:107
+#: ../../build/doc/quickstart/gdal_quickstart.rst:115
 msgid "Note:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:101
+#: ../../build/doc/quickstart/gdal_quickstart.rst:109
 msgid "Driver is \"GTiff/GeoTIFF\""
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:102
+#: ../../build/doc/quickstart/gdal_quickstart.rst:110
 msgid "Size is 10800x5400"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:103
+#: ../../build/doc/quickstart/gdal_quickstart.rst:111
 msgid "3 Bands of type Byte."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:104
+#: ../../build/doc/quickstart/gdal_quickstart.rst:112
 msgid "Coordinates"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:105
+#: ../../build/doc/quickstart/gdal_quickstart.rst:113
 msgid "no coordinate system"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:110
+#: ../../build/doc/quickstart/gdal_quickstart.rst:118
 msgid "Simple format translation"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:112
+#: ../../build/doc/quickstart/gdal_quickstart.rst:120
 msgid ""
-"First get to know your drivers. The `--formats` commandline switch of "
+"First get to know your drivers. The `--formats` command line switch of "
 "gdal_translate can be used to see a list of available format drivers."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:118
-msgid "Each format reports if it is"
-msgstr ""
-
-#: ../../build/doc/quickstart/gdal_quickstart.rst:116
-msgid "read only (ro),"
-msgstr ""
-
-#: ../../build/doc/quickstart/gdal_quickstart.rst:117
-msgid "read/write (rw) or"
-msgstr ""
-
-#: ../../build/doc/quickstart/gdal_quickstart.rst:118
-msgid "read/write/update (rw+)."
+#: ../../build/doc/quickstart/gdal_quickstart.rst:128
+msgid "Each format reports if it supports the following features:"
 msgstr ""
 
 #: ../../build/doc/quickstart/gdal_quickstart.rst:124
+msgid "read only (ro)"
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:125
+msgid "read/write (rw)"
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:126
+msgid "read/write/update (rw+)"
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:127
+msgid "supports virtual file systems (v)"
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:128
+msgid "supports subdatasets (s)"
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:134
 msgid ""
-"The `--format` commandline switch can be used to query details about a "
+"The `--format` command line switch can be used to query details about a "
 "particular driver, including creation options, and permitted data types."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:133
+#: ../../build/doc/quickstart/gdal_quickstart.rst:143
 msgid "Translation"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:135
+#: ../../build/doc/quickstart/gdal_quickstart.rst:145
 msgid ""
 "Translations are accomplished with the gdal_translate command. The "
 "default output format is GeoTIFF. The `-of` flag is used to select an "
 "output format and the -co flag is used to specify a creation option:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:143
+#: ../../build/doc/quickstart/gdal_quickstart.rst:153
 msgid "The `-ot` switch can be used to alter the output data type."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:149
+#: ../../build/doc/quickstart/gdal_quickstart.rst:159
 msgid "Use gdalinfo to verify data type."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:153
+#: ../../build/doc/quickstart/gdal_quickstart.rst:163
 msgid "Rescaling"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:155
+#: ../../build/doc/quickstart/gdal_quickstart.rst:165
 msgid "The `-outsize` switch can be used to set the size of the output file."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:161
+#: ../../build/doc/quickstart/gdal_quickstart.rst:171
 msgid "Use gdalinfo to verify the size."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:163
+#: ../../build/doc/quickstart/gdal_quickstart.rst:173
 msgid ""
 "The `-scale` switch can be used to rescale data. Explicit control of the "
 "input and output ranges is also available. The gdalinfo `-mm` switch can "
 "be used to see pixel min/max values."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:167
+#: ../../build/doc/quickstart/gdal_quickstart.rst:177
 msgid ""
 "Let's split our image into two with `-srcwin` which makes a copy based on"
 " pixel/line location (xoff yoff xsize ysize). You also could use "
@@ -205,50 +213,48 @@ msgid ""
 "lrx lry)."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:179
+#: ../../build/doc/quickstart/gdal_quickstart.rst:189
 msgid "Raster tileindex with gdaltindex"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:181
+#: ../../build/doc/quickstart/gdal_quickstart.rst:191
 msgid ""
 "You can build a shapefile as a raster tileindex. For every image a "
 "polygon is generated with the bounds of the extent of the polygon and the"
 " path to the file."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:189
+#: ../../build/doc/quickstart/gdal_quickstart.rst:199
 msgid ""
 "Have a look at your output shapefile with QGIS and ogrinfo (you will "
 "learn more about ogrinfo later in this tutorial)"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:217
+#: ../../build/doc/quickstart/gdal_quickstart.rst:231
 msgid "Reprojecting"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:219
+#: ../../build/doc/quickstart/gdal_quickstart.rst:233
 msgid ""
 "For this process we assume that HYP_50M_SR_W.tif has been properly "
-"created with bounds. As we saw before with gdainfo no coordinate system "
-"was set. So we assign WGS84 as coordinate system to the image in the "
-"first step."
+"created with bounds."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:228
+#: ../../build/doc/quickstart/gdal_quickstart.rst:236
 msgid ""
 "The gdalwarp command can be used to reproject images. Here we reproject "
 "the WGS84 geographic image to the Mercator projection:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:235
+#: ../../build/doc/quickstart/gdal_quickstart.rst:243
 msgid "Use gdalinfo to verify the change and have a look at the image."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:240
+#: ../../build/doc/quickstart/gdal_quickstart.rst:248
 msgid "Here we reproject to the Ortho projection."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:250
+#: ../../build/doc/quickstart/gdal_quickstart.rst:258
 msgid ""
 "Note how the poles are clipped? This is because the edges at the pole "
 "can't be reprojected gdalwarp does not read all the data. We can force "
@@ -256,143 +262,143 @@ msgid ""
 "resolve this."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:256
+#: ../../build/doc/quickstart/gdal_quickstart.rst:264
 msgid "Mosaicking"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:258
+#: ../../build/doc/quickstart/gdal_quickstart.rst:266
 msgid ""
 "gdal_merge.py is a python script that can be used for simple mosaicking "
 "tasks. Mosaic the east.tif and west.tif into a single file:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:266
+#: ../../build/doc/quickstart/gdal_quickstart.rst:274
 msgid ""
 "The same task can be accomplished with gdalwarp. gdalwarp has a variety "
 "of advantages over gdal_merge, but can be slow to merge many files:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:276
+#: ../../build/doc/quickstart/gdal_quickstart.rst:284
 msgid "Get to know OGR"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:283
+#: ../../build/doc/quickstart/gdal_quickstart.rst:291
 msgid "Open the shape file with a Desktop GIS like QGIS, and have a look."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:287
+#: ../../build/doc/quickstart/gdal_quickstart.rst:295
 msgid "Get information about the vector data with ogrinfo"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:308
+#: ../../build/doc/quickstart/gdal_quickstart.rst:317
 msgid "Get a summary about your data with ogrinfo together with `-so`."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:391
+#: ../../build/doc/quickstart/gdal_quickstart.rst:400
 msgid ""
 "If you run ogrinfo without a parameter you will get a summary about your "
 "data and afterwards a section for every dataset."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:398
+#: ../../build/doc/quickstart/gdal_quickstart.rst:407
 msgid ""
 "You can forward the result from ogrinfo to grep to filter and get only "
 "the attribute COUNTRY."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:414
+#: ../../build/doc/quickstart/gdal_quickstart.rst:423
 msgid ""
 "You can convert your data to other formats. Get the list of the supported"
 " formats with `--formats`."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:418
+#: ../../build/doc/quickstart/gdal_quickstart.rst:427
 msgid "Use ogr2ogr to convert data between file formats"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:420
+#: ../../build/doc/quickstart/gdal_quickstart.rst:429
 msgid ""
 "You can use ogr2ogr to converts simple features data between file "
 "formats. You can use `--formats` to get the list of the supported formats"
 " with read/write information."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:424
+#: ../../build/doc/quickstart/gdal_quickstart.rst:433
 msgid "Convert the countries to GML."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:433
+#: ../../build/doc/quickstart/gdal_quickstart.rst:442
 msgid "Things to try"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:435
+#: ../../build/doc/quickstart/gdal_quickstart.rst:444
 msgid "Here are some additional challenges for you to try:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:437
+#: ../../build/doc/quickstart/gdal_quickstart.rst:446
 msgid "Try gdalwarp or gdal_merge.py to mosaic your data"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:439
+#: ../../build/doc/quickstart/gdal_quickstart.rst:448
 msgid "Try gdaladdo to build internal overviews"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:441
+#: ../../build/doc/quickstart/gdal_quickstart.rst:450
 msgid ""
 "QGIS uses GDAL/OGR too to suport many formats. It also provides the "
 "GdalTools Plugin to process raster data. This plugin integrates the gdal-"
 "tools into QGIS."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:443
+#: ../../build/doc/quickstart/gdal_quickstart.rst:452
 msgid ""
 "Try ogr2ogr to import/export your vector data to other formats like "
 "PostGIS. Have a look at the options ogr2ogr provides."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:445
+#: ../../build/doc/quickstart/gdal_quickstart.rst:454
 msgid "Try the QGIS plugin OGR-Layer-Konverter."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:449
+#: ../../build/doc/quickstart/gdal_quickstart.rst:458
 msgid "What next?"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:451
+#: ../../build/doc/quickstart/gdal_quickstart.rst:460
 msgid ""
 "This is only the first step on the road to using GDAL and OGR. There is a"
 " lot more functionality you can try."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:454
+#: ../../build/doc/quickstart/gdal_quickstart.rst:463
 msgid "GDAL Project home"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:456
+#: ../../build/doc/quickstart/gdal_quickstart.rst:465
 msgid "https://gdal.org"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:458
+#: ../../build/doc/quickstart/gdal_quickstart.rst:467
 msgid "GDAL Raster Tutorial"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:460
+#: ../../build/doc/quickstart/gdal_quickstart.rst:469
 msgid "https://gdal.org/en/latest/tutorials/raster_api_tut.html"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:462
+#: ../../build/doc/quickstart/gdal_quickstart.rst:471
 msgid "GDAL Workshop"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:464
+#: ../../build/doc/quickstart/gdal_quickstart.rst:473
 msgid "https://download.osgeo.org/gdal/workshop/foss4ge2015/workshop_gdal.html"
 msgstr ""
 
-#: ../../build/doc/<rst_epilog>:13
+#: ../../build/doc/<rst_epilog>:11
 msgid "vmdk"
 msgstr ""
 
-#: ../../build/doc/<rst_epilog>:16
+#: ../../build/doc/<rst_epilog>:14
 msgid "nologo"
 msgstr ""
 

--- a/locale/pot/overview/gdal_overview.pot
+++ b/locale/pot/overview/gdal_overview.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: OSGeoLive 17.0.0\n"
+"Project-Id-Version: OSGeoLive 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-26 14:03+0000\n"
+"POT-Creation-Date: 2025-05-13 22:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,11 +57,11 @@ msgid "Support for large files - larger than 4GB"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:48
-msgid "Library access from Python, Java, C#, Ruby, VB6 and Perl"
+msgid "Library access from Python, Java, and C#"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:49
-msgid "Coordinate system engine built on PROJ.4 and OGC Well Known Text coordinate system descriptions"
+msgid "Coordinate system engine built on PROJ and OGC Well Known Text coordinate system descriptions"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:52
@@ -77,11 +77,11 @@ msgid "These include:"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:58
-msgid "**Raster:** GeoTIFF, Erdas Imagine, SDTS, ESRI Grids, ECW, MrSID, JPEG2000, DTED, NITF, GeoPackage and more ..."
+msgid "**Raster:** GeoTIFF / COG, HDF, NetCDF, GeoPackage, JPEG2000, ECW, ENVI, KEA, MrSID, DTED, NITF and more ..."
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:59
-msgid "**Vector:** GeoPackage, ESRI Shapefile, GML, GeoJSON, AutoCAD DWG, MapInfo (tab and mid/mif), ESRI Coverages, ESRI Personal Geodatabase, DGN, PostGIS, Oracle Spatial, and more ..."
+msgid "**Vector:** GeoPackage, ESRI Shapefile, GeoJSON, PostGIS, (Geo)Parquet, ESRI File Geodatabase, FlatGeobuf, GML, AutoCAD DWG, MapInfo, DGN, Oracle Spatial, and more ..."
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:62
@@ -113,7 +113,7 @@ msgid "**Supported Platforms:** Windows, Linux, Mac"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:77
-msgid "**API Interfaces:** C, C++, Python, Java, C#, Ruby, VB6 and Perl"
+msgid "**API Interfaces:** C, C++, Python, Java, C#"
 msgstr ""
 
 #: ../../build/doc/overview/gdal_overview.rst:79
@@ -128,11 +128,11 @@ msgstr ""
 msgid ":doc:`Quickstart documentation <../quickstart/gdal_quickstart>`"
 msgstr ""
 
-#: ../../build/doc/<rst_epilog>:13
+#: ../../build/doc/<rst_epilog>:11
 msgid "vmdk"
 msgstr ""
 
-#: ../../build/doc/<rst_epilog>:16
+#: ../../build/doc/<rst_epilog>:14
 msgid "nologo"
 msgstr ""
 

--- a/locale/pot/quickstart/gdal_quickstart.pot
+++ b/locale/pot/quickstart/gdal_quickstart.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: OSGeoLive 17.0.0\n"
+"Project-Id-Version: OSGeoLive 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-14 04:54+0000\n"
+"POT-Creation-Date: 2025-05-13 22:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,255 +84,263 @@ msgstr ""
 msgid "You will then find a NaturalEarth Raster file and a .tfw World-file at: ::"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:68
+#: ../../build/doc/quickstart/gdal_quickstart.rst:69
 msgid "Open the file with a Desktop GIS like QGIS, and have a look."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:71
+#: ../../build/doc/quickstart/gdal_quickstart.rst:72
 msgid "Get information about the raster data with gdalinfo"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:107
+#: ../../build/doc/quickstart/gdal_quickstart.rst:115
 msgid "Note:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:101
+#: ../../build/doc/quickstart/gdal_quickstart.rst:109
 msgid "Driver is \"GTiff/GeoTIFF\""
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:102
+#: ../../build/doc/quickstart/gdal_quickstart.rst:110
 msgid "Size is 10800x5400"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:103
+#: ../../build/doc/quickstart/gdal_quickstart.rst:111
 msgid "3 Bands of type Byte."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:104
+#: ../../build/doc/quickstart/gdal_quickstart.rst:112
 msgid "Coordinates"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:105
+#: ../../build/doc/quickstart/gdal_quickstart.rst:113
 msgid "no coordinate system"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:110
+#: ../../build/doc/quickstart/gdal_quickstart.rst:118
 msgid "Simple format translation"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:112
-msgid "First get to know your drivers. The `--formats` commandline switch of gdal_translate can be used to see a list of available format drivers."
+#: ../../build/doc/quickstart/gdal_quickstart.rst:120
+msgid "First get to know your drivers. The `--formats` command line switch of gdal_translate can be used to see a list of available format drivers."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:118
-msgid "Each format reports if it is"
-msgstr ""
-
-#: ../../build/doc/quickstart/gdal_quickstart.rst:116
-msgid "read only (ro),"
-msgstr ""
-
-#: ../../build/doc/quickstart/gdal_quickstart.rst:117
-msgid "read/write (rw) or"
-msgstr ""
-
-#: ../../build/doc/quickstart/gdal_quickstart.rst:118
-msgid "read/write/update (rw+)."
+#: ../../build/doc/quickstart/gdal_quickstart.rst:128
+msgid "Each format reports if it supports the following features:"
 msgstr ""
 
 #: ../../build/doc/quickstart/gdal_quickstart.rst:124
-msgid "The `--format` commandline switch can be used to query details about a particular driver, including creation options, and permitted data types."
+msgid "read only (ro)"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:133
-msgid "Translation"
+#: ../../build/doc/quickstart/gdal_quickstart.rst:125
+msgid "read/write (rw)"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:135
-msgid "Translations are accomplished with the gdal_translate command. The default output format is GeoTIFF. The `-of` flag is used to select an output format and the -co flag is used to specify a creation option:"
+#: ../../build/doc/quickstart/gdal_quickstart.rst:126
+msgid "read/write/update (rw+)"
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:127
+msgid "supports virtual file systems (v)"
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:128
+msgid "supports subdatasets (s)"
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:134
+msgid "The `--format` command line switch can be used to query details about a particular driver, including creation options, and permitted data types."
 msgstr ""
 
 #: ../../build/doc/quickstart/gdal_quickstart.rst:143
-msgid "The `-ot` switch can be used to alter the output data type."
+msgid "Translation"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:149
-msgid "Use gdalinfo to verify data type."
+#: ../../build/doc/quickstart/gdal_quickstart.rst:145
+msgid "Translations are accomplished with the gdal_translate command. The default output format is GeoTIFF. The `-of` flag is used to select an output format and the -co flag is used to specify a creation option:"
 msgstr ""
 
 #: ../../build/doc/quickstart/gdal_quickstart.rst:153
-msgid "Rescaling"
+msgid "The `-ot` switch can be used to alter the output data type."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:155
-msgid "The `-outsize` switch can be used to set the size of the output file."
-msgstr ""
-
-#: ../../build/doc/quickstart/gdal_quickstart.rst:161
-msgid "Use gdalinfo to verify the size."
+#: ../../build/doc/quickstart/gdal_quickstart.rst:159
+msgid "Use gdalinfo to verify data type."
 msgstr ""
 
 #: ../../build/doc/quickstart/gdal_quickstart.rst:163
+msgid "Rescaling"
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:165
+msgid "The `-outsize` switch can be used to set the size of the output file."
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:171
+msgid "Use gdalinfo to verify the size."
+msgstr ""
+
+#: ../../build/doc/quickstart/gdal_quickstart.rst:173
 msgid "The `-scale` switch can be used to rescale data. Explicit control of the input and output ranges is also available. The gdalinfo `-mm` switch can be used to see pixel min/max values."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:167
+#: ../../build/doc/quickstart/gdal_quickstart.rst:177
 msgid "Let's split our image into two with `-srcwin` which makes a copy based on pixel/line location (xoff yoff xsize ysize). You also could use `-projwin` and define the corners in georeferenced coordinates (ulx uly lrx lry)."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:179
+#: ../../build/doc/quickstart/gdal_quickstart.rst:189
 msgid "Raster tileindex with gdaltindex"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:181
+#: ../../build/doc/quickstart/gdal_quickstart.rst:191
 msgid "You can build a shapefile as a raster tileindex. For every image a polygon is generated with the bounds of the extent of the polygon and the path to the file."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:189
+#: ../../build/doc/quickstart/gdal_quickstart.rst:199
 msgid "Have a look at your output shapefile with QGIS and ogrinfo (you will learn more about ogrinfo later in this tutorial)"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:217
+#: ../../build/doc/quickstart/gdal_quickstart.rst:231
 msgid "Reprojecting"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:219
-msgid "For this process we assume that HYP_50M_SR_W.tif has been properly created with bounds. As we saw before with gdainfo no coordinate system was set. So we assign WGS84 as coordinate system to the image in the first step."
+#: ../../build/doc/quickstart/gdal_quickstart.rst:233
+msgid "For this process we assume that HYP_50M_SR_W.tif has been properly created with bounds."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:228
+#: ../../build/doc/quickstart/gdal_quickstart.rst:236
 msgid "The gdalwarp command can be used to reproject images. Here we reproject the WGS84 geographic image to the Mercator projection:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:235
+#: ../../build/doc/quickstart/gdal_quickstart.rst:243
 msgid "Use gdalinfo to verify the change and have a look at the image."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:240
+#: ../../build/doc/quickstart/gdal_quickstart.rst:248
 msgid "Here we reproject to the Ortho projection."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:250
+#: ../../build/doc/quickstart/gdal_quickstart.rst:258
 msgid "Note how the poles are clipped? This is because the edges at the pole can't be reprojected gdalwarp does not read all the data. We can force gdalwarp to read a bunch of surplus data around chunks as one way to resolve this."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:256
+#: ../../build/doc/quickstart/gdal_quickstart.rst:264
 msgid "Mosaicking"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:258
+#: ../../build/doc/quickstart/gdal_quickstart.rst:266
 msgid "gdal_merge.py is a python script that can be used for simple mosaicking tasks. Mosaic the east.tif and west.tif into a single file:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:266
+#: ../../build/doc/quickstart/gdal_quickstart.rst:274
 msgid "The same task can be accomplished with gdalwarp. gdalwarp has a variety of advantages over gdal_merge, but can be slow to merge many files:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:276
+#: ../../build/doc/quickstart/gdal_quickstart.rst:284
 msgid "Get to know OGR"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:283
+#: ../../build/doc/quickstart/gdal_quickstart.rst:291
 msgid "Open the shape file with a Desktop GIS like QGIS, and have a look."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:287
+#: ../../build/doc/quickstart/gdal_quickstart.rst:295
 msgid "Get information about the vector data with ogrinfo"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:308
+#: ../../build/doc/quickstart/gdal_quickstart.rst:317
 msgid "Get a summary about your data with ogrinfo together with `-so`."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:391
+#: ../../build/doc/quickstart/gdal_quickstart.rst:400
 msgid "If you run ogrinfo without a parameter you will get a summary about your data and afterwards a section for every dataset."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:398
+#: ../../build/doc/quickstart/gdal_quickstart.rst:407
 msgid "You can forward the result from ogrinfo to grep to filter and get only the attribute COUNTRY."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:414
+#: ../../build/doc/quickstart/gdal_quickstart.rst:423
 msgid "You can convert your data to other formats. Get the list of the supported formats with `--formats`."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:418
+#: ../../build/doc/quickstart/gdal_quickstart.rst:427
 msgid "Use ogr2ogr to convert data between file formats"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:420
+#: ../../build/doc/quickstart/gdal_quickstart.rst:429
 msgid "You can use ogr2ogr to converts simple features data between file formats. You can use `--formats` to get the list of the supported formats with read/write information."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:424
+#: ../../build/doc/quickstart/gdal_quickstart.rst:433
 msgid "Convert the countries to GML."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:433
+#: ../../build/doc/quickstart/gdal_quickstart.rst:442
 msgid "Things to try"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:435
+#: ../../build/doc/quickstart/gdal_quickstart.rst:444
 msgid "Here are some additional challenges for you to try:"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:437
+#: ../../build/doc/quickstart/gdal_quickstart.rst:446
 msgid "Try gdalwarp or gdal_merge.py to mosaic your data"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:439
+#: ../../build/doc/quickstart/gdal_quickstart.rst:448
 msgid "Try gdaladdo to build internal overviews"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:441
+#: ../../build/doc/quickstart/gdal_quickstart.rst:450
 msgid "QGIS uses GDAL/OGR too to suport many formats. It also provides the GdalTools Plugin to process raster data. This plugin integrates the gdal-tools into QGIS."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:443
+#: ../../build/doc/quickstart/gdal_quickstart.rst:452
 msgid "Try ogr2ogr to import/export your vector data to other formats like PostGIS. Have a look at the options ogr2ogr provides."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:445
+#: ../../build/doc/quickstart/gdal_quickstart.rst:454
 msgid "Try the QGIS plugin OGR-Layer-Konverter."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:449
+#: ../../build/doc/quickstart/gdal_quickstart.rst:458
 msgid "What next?"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:451
+#: ../../build/doc/quickstart/gdal_quickstart.rst:460
 msgid "This is only the first step on the road to using GDAL and OGR. There is a lot more functionality you can try."
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:454
+#: ../../build/doc/quickstart/gdal_quickstart.rst:463
 msgid "GDAL Project home"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:456
+#: ../../build/doc/quickstart/gdal_quickstart.rst:465
 msgid "https://gdal.org"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:458
+#: ../../build/doc/quickstart/gdal_quickstart.rst:467
 msgid "GDAL Raster Tutorial"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:460
+#: ../../build/doc/quickstart/gdal_quickstart.rst:469
 msgid "https://gdal.org/en/latest/tutorials/raster_api_tut.html"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:462
+#: ../../build/doc/quickstart/gdal_quickstart.rst:471
 msgid "GDAL Workshop"
 msgstr ""
 
-#: ../../build/doc/quickstart/gdal_quickstart.rst:464
+#: ../../build/doc/quickstart/gdal_quickstart.rst:473
 msgid "https://download.osgeo.org/gdal/workshop/foss4ge2015/workshop_gdal.html"
 msgstr ""
 
-#: ../../build/doc/<rst_epilog>:13
+#: ../../build/doc/<rst_epilog>:11
 msgid "vmdk"
 msgstr ""
 
-#: ../../build/doc/<rst_epilog>:16
+#: ../../build/doc/<rst_epilog>:14
 msgid "nologo"
 msgstr ""
 


### PR DESCRIPTION
Minor updates following a run through of the Quickstart using osgeolive-nightly-build130-amd64-663f4e3-master.iso

- Slightly different outputs in new version of GDAL and Natural Earth (all commands still work fine)
- Highlight most used data formats based on https://gdal.org/en/stable/community/user_survey_2024.html
- Remove references to Perl, VB6, Ruby (SWIG bindings no longer supported)
