### PR TITLE
These changes generate presentation locally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 if ( ${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR} )
     message(FATAL_ERROR "In-source builds not allowed.
     Please make a new directory (called a build directory) and run CMake from there.

--- a/doc/prior_applications.rst
+++ b/doc/prior_applications.rst
@@ -6,7 +6,7 @@ Previously available applications
 
 
 .. csv-table::
-    :header:  "", "Name", "", "Last Available", "Description"
+    :header:  kind, Name, Quickstart, Last Available, Description
     :widths: 5, 15, 15, 10, 30
     :delim: %
 

--- a/locale/en/LC_MESSAGES/presentation.po
+++ b/locale/en/LC_MESSAGES/presentation.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OSGeoLive 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-23 16:57+0000\n"
+"POT-Creation-Date: 2025-07-14 20:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgid "Version: 17.0"
 msgstr ""
 
 #: ../../build/presentation/revealjs/presentation.rst:14
-msgid "Released: December 2024"
+msgid "Released: August 2025"
 msgstr ""
 
 #: ../../build/presentation/revealjs/presentation.rst:18
@@ -74,7 +74,7 @@ msgid "What is new in 17.0"
 msgstr ""
 
 #: ../../build/presentation/revealjs/presentation.rst:64
-msgid "Updated to Lubuntu 22.04.2 LTS"
+msgid "Updated to Lubuntu 24.04.2 LTS"
 msgstr ""
 
 #: ../../build/presentation/revealjs/presentation.rst:68

--- a/locale/en/LC_MESSAGES/prior_applications.po
+++ b/locale/en/LC_MESSAGES/prior_applications.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OSGeoLive 17.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-18 17:21+0000\n"
+"POT-Creation-Date: 2025-07-14 20:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -17,14 +17,22 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: ../../build/doc/prior_applications.rst:5
 msgid "Previously available applications"
 msgstr ""
 
 #: ../../build/doc/prior_applications.rst:1
+msgid "kind"
+msgstr ""
+
+#: ../../build/doc/prior_applications.rst:1
 msgid "Name"
+msgstr ""
+
+#: ../../build/doc/prior_applications.rst:1
+msgid "Quickstart"
 msgstr ""
 
 #: ../../build/doc/prior_applications.rst:1

--- a/locale/pot/presentation.pot
+++ b/locale/pot/presentation.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2022, OSGeoLive
+# Copyright (C) 2025, OSGeoLive
 # This file is distributed under the same license as the OSGeoLive package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: OSGeoLive 15\n"
+"Project-Id-Version: OSGeoLive 17\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-23 16:57+0000\n"
+"POT-Creation-Date: 2025-07-14 20:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgid "Version: 17.0"
 msgstr ""
 
 #: ../../build/presentation/revealjs/presentation.rst:14
-msgid "Released: December 2024"
+msgid "Released: August 2025"
 msgstr ""
 
 #: ../../build/presentation/revealjs/presentation.rst:18
@@ -67,7 +67,7 @@ msgid "What is new in 17.0"
 msgstr ""
 
 #: ../../build/presentation/revealjs/presentation.rst:64
-msgid "Updated to Lubuntu 22.04.2 LTS"
+msgid "Updated to Lubuntu 24.04.2 LTS"
 msgstr ""
 
 #: ../../build/presentation/revealjs/presentation.rst:68

--- a/locale/pot/prior_applications.pot
+++ b/locale/pot/prior_applications.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OSGeoLive 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-18 17:21+0000\n"
+"POT-Creation-Date: 2025-07-14 20:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,15 @@ msgid "Previously available applications"
 msgstr ""
 
 #: ../../build/doc/prior_applications.rst:1
+msgid "kind"
+msgstr ""
+
+#: ../../build/doc/prior_applications.rst:1
 msgid "Name"
+msgstr ""
+
+#: ../../build/doc/prior_applications.rst:1
+msgid "Quickstart"
 msgstr ""
 
 #: ../../build/doc/prior_applications.rst:1

--- a/presentation/conf.py
+++ b/presentation/conf.py
@@ -2,13 +2,15 @@
 
 # -- Path setup --------------------------------------------------------------
 import os
+from urllib.parse import urljoin
+from sphinx_revealjs.utils import get_revealjs_path
 
 # -- Project information -----------------------------------------------------
 project = "OSGeoLive"
-copyright = "2022, OSGeoLive"
+copyright = "2025, OSGeoLive"
 author = "Vicky Vergara"
-version = "15"
-release = "August, 2022"
+version = "17"
+release = "August, 2025"
 
 # -- General configuration ---------------------------------------------------
 extensions = [
@@ -30,21 +32,20 @@ html_theme_options = {
 #html_static_path = ["@CMAKE_SOURCE_DIR@/doc/_static"]
 
 # -- Options for Reveal.js output ---------------------------------------------
+revealjs_html_theme = "revealjs-simple"
 revealjs_static_path = ["@CMAKE_SOURCE_DIR@/doc/_static"]
 revealjs_style_theme = "white"
-revealjs_script_conf = """
-    {
-        controls: true,
-        progress: true,
-        history: true,
-        center: true,
-        transition: "cube",
-    }
-"""
+revealjs_script_conf = {
+    "controls": True,
+    "progress": True,
+    "hash": True,
+    "center": True,
+    "transition": "cube",
+}
 revealjs_script_plugins = [
     {
         "name": "RevealNotes",
-        "src": "revealjs4/plugin/notes/notes.js",
+        "src": "revealjs/plugin/notes/notes.js",
     },
 ]
 revealjs_css_files = [

--- a/presentation/start_presentation.txt
+++ b/presentation/start_presentation.txt
@@ -7,7 +7,7 @@ OSGeoLive
 
 Version: @OSGeoLiveDoc_VERSION_MAJOR@.0
 
-Released: December 2024
+Released: August 2025
 
 |
 
@@ -57,7 +57,7 @@ What is new in @OSGeoLiveDoc_VERSION_MAJOR@.0
 What is new in @OSGeoLiveDoc_VERSION_MAJOR@.0
 --------------------------------------------------------------------------------
 
-Updated to Lubuntu 22.04.2 LTS
+Updated to Lubuntu 24.04.2 LTS
 
 .. revealjs-break::
 


### PR DESCRIPTION
This PR tries to fix the presentation on [development](https://osgeo.github.io/OSGeoLive-doc/en/index.html)

TODO:

- Check if the build for the ISO shows the presentation also.
- I used August 2025 as "release date" on the presentation but it needs to be changed when the final release month is known. (maybe I need to get the build date on cmake)